### PR TITLE
fix: sync pnpm lockfile after v1.1.0 release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
   packages/duraflows-kysely:
     dependencies:
       '@duraflows/core':
-        specifier: workspace:^
-        version: link:../duraflows-core
+        specifier: ^1.1.0
+        version: 1.1.0
       kysely:
         specifier: ^0.28.16
         version: 0.28.16
@@ -77,8 +77,8 @@ importers:
   packages/duraflows-nestjs:
     dependencies:
       '@duraflows/core':
-        specifier: workspace:^
-        version: link:../duraflows-core
+        specifier: ^1.1.0
+        version: 1.1.0
       '@nestjs/common':
         specifier: ^11.1.19
         version: 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -105,8 +105,8 @@ importers:
   packages/duraflows-pg:
     dependencies:
       '@duraflows/core':
-        specifier: workspace:^
-        version: link:../duraflows-core
+        specifier: ^1.1.0
+        version: 1.1.0
       pg:
         specifier: ^8.13.0
         version: 8.20.0
@@ -228,6 +228,9 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
+
+  '@duraflows/core@1.1.0':
+    resolution: {integrity: sha512-nFrtjt5d7VTpZcD94JtG4yDAqGFpLF7yQ80zzBmJn4JQcTi5bj2MvDcQTkDlGru0bZP59O3+6iklab7V/x4QJw==}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -2468,6 +2471,10 @@ snapshots:
     optionalDependencies:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.4.0
+
+  '@duraflows/core@1.1.0':
+    dependencies:
+      '@camcima/finita': 2.2.0
 
   '@emnapi/core@1.9.2':
     dependencies:


### PR DESCRIPTION
## Summary

- Re-run `pnpm install` so the lockfile records `@duraflows/core` at `^1.1.0` / `1.1.0` instead of the stale `workspace:^` / `link:` specifier carried over from the development branch.

## Why

CI fails on `main` after the `chore: release v1.1.0` commit (6ec1b28) with:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with .../packages/duraflows-kysely/package.json
specifiers in the lockfile ({"@duraflows/core":"workspace:^",...}) don't match specs in package.json ({"@duraflows/core":"^1.1.0",...})
```

release-it bumped the downstream packages' `@duraflows/core` dep to `^1.1.0` but did not regenerate the lockfile in the same commit, leaving the workspace specifier in place. This mirrors the prior post-release sync `3cd5ea5`.

## Test plan

- [x] `pnpm install --frozen-lockfile` (clean)
- [x] `pnpm run build` (clean)
- [x] `pnpm test` (383/383 passing)
- [ ] CI green on this PR