### PR TITLE
chore(release): prevent lockfile drift after release

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+link-workspace-packages=true

--- a/.release-it.json
+++ b/.release-it.json
@@ -11,7 +11,7 @@
   },
   "hooks": {
     "before:bump": "pnpm -r exec npm version ${version} --no-git-tag-version --allow-same-version && pnpm --filter @duraflows/pg exec npm pkg set \"dependencies.@duraflows/core=^${version}\" && pnpm --filter @duraflows/kysely exec npm pkg set \"dependencies.@duraflows/core=^${version}\" && pnpm --filter @duraflows/nestjs exec npm pkg set \"dependencies.@duraflows/core=^${version}\"",
-    "after:bump": "pnpm run build",
+    "after:bump": "pnpm install --lockfile-only && pnpm run build",
     "before:release": "pnpm -r publish --no-git-checks"
   },
   "plugins": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
   packages/duraflows-kysely:
     dependencies:
       '@duraflows/core':
-        specifier: workspace:^
+        specifier: ^1.1.0
         version: link:../duraflows-core
       kysely:
         specifier: ^0.28.16
@@ -77,7 +77,7 @@ importers:
   packages/duraflows-nestjs:
     dependencies:
       '@duraflows/core':
-        specifier: workspace:^
+        specifier: ^1.1.0
         version: link:../duraflows-core
       '@nestjs/common':
         specifier: ^11.1.19
@@ -105,7 +105,7 @@ importers:
   packages/duraflows-pg:
     dependencies:
       '@duraflows/core':
-        specifier: workspace:^
+        specifier: ^1.1.0
         version: link:../duraflows-core
       pg:
         specifier: ^8.13.0


### PR DESCRIPTION
## Summary

Stops `chore: release vX.Y.Z` commits from leaving the lockfile out of sync with the package.json bumps that release-it just performed. Two narrow changes:

- **`.npmrc`**: enable `link-workspace-packages=true` so concrete-version specs like `^1.1.0` still resolve to local workspace packages (pnpm v9 changed the default to `false`). With this on, the lockfile records `link:../duraflows-core` for the in-monorepo deps regardless of whether the new version is published yet — so `pnpm install --lockfile-only` works fine in the release commit even before npm publish.
- **`.release-it.json`**: extend `after:bump` to run `pnpm install --lockfile-only` before the existing `pnpm run build`, so the release commit carries the regenerated lockfile alongside the version bumps.

The `pnpm-lock.yaml` diff included here is what `pnpm install` produces under the new `.npmrc` — making the in-flight v1.1.0 specifiers consistent with their workspace links. This **supersedes #20** (which patched the symptom; this fixes the cause).

## Why

We have already had to ship two manual lockfile-sync commits for this exact issue: `3cd5ea5` (post-v1.0 release) and the in-flight v1.1.0 fix (PR #20). Releases will keep breaking CI on `main` until the release flow itself includes the lockfile.

## Test plan

- [x] `pnpm install --frozen-lockfile` (clean)
- [x] `pnpm run build` (clean)
- [x] `pnpm test` (383/383 passing)
- [x] `pnpm run lint` (clean)
- [x] `pnpm run format:check` (clean)
- [ ] CI green on this PR
- [ ] Next release does not require a manual lockfile-sync follow-up