### PR TITLE
chore: release v2.1.0

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -12,7 +12,7 @@
   "hooks": {
     "before:bump": "pnpm -r exec npm version ${version} --no-git-tag-version --allow-same-version && pnpm --filter @duraflows/pg exec npm pkg set \"dependencies.@duraflows/core=^${version}\" && pnpm --filter @duraflows/kysely exec npm pkg set \"dependencies.@duraflows/core=^${version}\" && pnpm --filter @duraflows/nestjs exec npm pkg set \"dependencies.@duraflows/core=^${version}\"",
     "after:bump": "pnpm install --lockfile-only && pnpm run build",
-    "before:release": "pnpm -r publish --no-git-checks"
+    "after:release": "pnpm -r publish --no-git-checks"
   },
   "plugins": {
     "@release-it/conventional-changelog": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [2.1.0](https://github.com/camcima/duraflows/compare/v1.1.0...v2.1.0) (2026-05-30)
+
+### ⚠ BREAKING CHANGES
+
+* **core:** @duraflows/core now depends on @camcima/finita ^3.0.0,
+which requires Node.js >= 20. The duraflows error contract is unchanged:
+WorkflowCompiler.compile() still throws WorkflowDefinitionError and
+EventExecutor.execute() still throws WorkflowError / InvalidEventError /
+CommandFailureError. Specific message text for "unknown target state",
+"unknown error state", and "missing initial state" cases now originates
+from ProcessBuilder.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+### Features
+
+* **core:** upgrade to @camcima/finita v3 ([ddfa91c](https://github.com/camcima/duraflows/commit/ddfa91c97667da21eba458dad59821f80ba39a45))
+* improve type-safety and others minor changes ([#36](https://github.com/camcima/duraflows/issues/36)) ([d65993b](https://github.com/camcima/duraflows/commit/d65993b74455d38b142ff8d73ee02270d4f60eac))
+
+### Bug Fixes
+
+* **core:** merge target/error transitions when both lead to the same state ([8dbbf6b](https://github.com/camcima/duraflows/commit/8dbbf6bf204925519c504d45348ad3016c49ddab))
+
 ## [1.1.0](https://github.com/camcima/duraflows/compare/v1.0.0...v1.1.0) (2026-04-27)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "duraflows-persistence-adapter": "skills/duraflows-persistence-adapter/SKILL.md",
     "duraflows-reviewer": "skills/duraflows-reviewer/SKILL.md"
   },
-  "version": "1.1.0",
+  "version": "2.1.0",
   "license": "MIT"
 }

--- a/packages/duraflows-core/package.json
+++ b/packages/duraflows-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duraflows/core",
-  "version": "1.1.0",
+  "version": "2.1.0",
   "description": "Framework-agnostic durable workflow runtime for TypeScript, built on @camcima/finita. Ships the runtime, types, persistence interfaces, and observer hooks.",
   "keywords": [
     "workflow",

--- a/packages/duraflows-kysely/package.json
+++ b/packages/duraflows-kysely/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duraflows/kysely",
-  "version": "1.1.0",
+  "version": "2.1.0",
   "description": "PostgreSQL persistence adapter for duraflows using `kysely`. Integrates with kysely's type-safe query builder and AsyncLocalStorage-based transaction context.",
   "keywords": [
     "duraflows",
@@ -51,7 +51,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@duraflows/core": "^1.1.0",
+    "@duraflows/core": "^2.1.0",
     "kysely": "^0.29.2"
   },
   "peerDependencies": {

--- a/packages/duraflows-nestjs/package.json
+++ b/packages/duraflows-nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duraflows/nestjs",
-  "version": "1.1.0",
+  "version": "2.1.0",
   "description": "NestJS integration for duraflows: dependency injection, services, optional REST controllers, and @WorkflowCommand decorator for DI-backed command handlers.",
   "keywords": [
     "duraflows",
@@ -50,7 +50,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@duraflows/core": "^1.1.0",
+    "@duraflows/core": "^2.1.0",
     "@nestjs/common": "^11.1.24",
     "@nestjs/core": "^11.1.24",
     "class-transformer": "^0.5.1",

--- a/packages/duraflows-pg/package.json
+++ b/packages/duraflows-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duraflows/pg",
-  "version": "1.1.0",
+  "version": "2.1.0",
   "description": "PostgreSQL persistence adapter for duraflows using `pg`. Provides transaction runner, workflow instance store, and history store with row-level locking for safe concurrent access.",
   "keywords": [
     "duraflows",
@@ -50,7 +50,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@duraflows/core": "^1.1.0",
+    "@duraflows/core": "^2.1.0",
     "pg": "^8.21.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
   packages/duraflows-kysely:
     dependencies:
       '@duraflows/core':
-        specifier: ^1.1.0
+        specifier: ^2.1.0
         version: link:../duraflows-core
       kysely:
         specifier: ^0.29.2
@@ -80,7 +80,7 @@ importers:
   packages/duraflows-nestjs:
     dependencies:
       '@duraflows/core':
-        specifier: ^1.1.0
+        specifier: ^2.1.0
         version: link:../duraflows-core
       '@nestjs/common':
         specifier: ^11.1.24
@@ -108,7 +108,7 @@ importers:
   packages/duraflows-pg:
     dependencies:
       '@duraflows/core':
-        specifier: ^1.1.0
+        specifier: ^2.1.0
         version: link:../duraflows-core
       pg:
         specifier: ^8.21.0


### PR DESCRIPTION
## Release v2.1.0

Prepares the `2.1.0` release: version bump across all workspace packages + generated CHANGELOG. **No tag or npm publish happens in this PR** — those run after merge.

### Why 2.1.0 (not 2.0.0)
`@duraflows/*@2.0.0` is already on npm — it was published by an **aborted release run on May 1** that never completed the git side (no tag/commit/release reached `main`). This release ships the current `main` as **2.1.0**: SemVer-honest since 2.0.0 already carried the finita-v3 breaking change, and `#36` (type-safety) is a new feature on top.

### What's in this PR
- Bump root + all 4 packages to `2.1.0`; internal deps pinned to `@duraflows/core@^2.1.0`
- Generated `CHANGELOG.md` entry (finita-v3 breaking change, `#36` feat, transition-merge fix)
- **`chore(release)` config fix:** moved `pnpm -r publish` from `before:release` → `after:release` in `.release-it.json`, so npm only advances *after* git commit/tag/push succeed. This is the root cause of the May 1 npm/git split and the failed runs today — publishing last makes git the source of truth.

### After merge
Tag `v2.1.0` on `main`, create the GitHub release, then `pnpm -r publish` the four packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)