### PR TITLE
docs(contributing): list all four packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,14 @@ Thanks for your interest in contributing! This guide covers everything you need 
 
 ## Project Structure
 
-This is a monorepo with three packages:
+This is a monorepo with four packages:
 
-| Package             | Path                        | Description                          |
-| ------------------- | --------------------------- | ------------------------------------ |
-| `@duraflows/core`   | `packages/duraflows-core`   | Framework-agnostic runtime and types |
-| `@duraflows/pg`     | `packages/duraflows-pg`     | PostgreSQL persistence adapter       |
-| `@duraflows/nestjs` | `packages/duraflows-nestjs` | NestJS module integration            |
+| Package             | Path                        | Description                             |
+| ------------------- | --------------------------- | --------------------------------------- |
+| `@duraflows/core`   | `packages/duraflows-core`   | Framework-agnostic runtime and types    |
+| `@duraflows/pg`     | `packages/duraflows-pg`     | PostgreSQL persistence adapter (`pg`)   |
+| `@duraflows/kysely` | `packages/duraflows-kysely` | PostgreSQL persistence adapter (Kysely) |
+| `@duraflows/nestjs` | `packages/duraflows-nestjs` | NestJS module integration               |
 
 ## Development Workflow
 


### PR DESCRIPTION
The **Project Structure** table in `CONTRIBUTING.md` said *"three packages"* and omitted `@duraflows/kysely`.

- Corrects "three" → "four" packages
- Adds the `@duraflows/kysely` row
- Differentiates the two PostgreSQL adapters: `@duraflows/pg` (`pg` driver) vs `@duraflows/kysely` (Kysely query builder)

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)