### PR TITLE
fix: address 2026-06-11 code review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,35 @@ jobs:
           flags: unit
           fail_ci_if_error: true
 
+  integration:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: duraflows_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9.15.0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm vitest run packages/duraflows-pg/tests/integration packages/duraflows-kysely/tests/integration
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/duraflows_test
+
   osv-scanner:
     runs-on: ubuntu-latest
     permissions:

--- a/.release-it.json
+++ b/.release-it.json
@@ -10,7 +10,7 @@
     "publish": false
   },
   "hooks": {
-    "before:bump": "pnpm -r exec npm version ${version} --no-git-tag-version --allow-same-version && pnpm --filter @duraflows/pg exec npm pkg set \"dependencies.@duraflows/core=^${version}\" && pnpm --filter @duraflows/kysely exec npm pkg set \"dependencies.@duraflows/core=^${version}\" && pnpm --filter @duraflows/nestjs exec npm pkg set \"dependencies.@duraflows/core=^${version}\"",
+    "before:bump": "pnpm -r exec npm version ${version} --no-git-tag-version --allow-same-version && pnpm --filter @duraflows/pg exec npm pkg set \"peerDependencies.@duraflows/core=^${version}\" && pnpm --filter @duraflows/kysely exec npm pkg set \"peerDependencies.@duraflows/core=^${version}\" && pnpm --filter @duraflows/nestjs exec npm pkg set \"peerDependencies.@duraflows/core=^${version}\"",
     "after:bump": "pnpm install --lockfile-only && pnpm run build",
     "after:release": "pnpm -r publish --no-git-checks"
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! This guide covers everything you need 
 
 - Node.js 20+
 - pnpm 9.15+ (the repo pins `pnpm@9.15.0` via the `packageManager` field; Corepack will fetch it automatically)
-- PostgreSQL 13+ (for running persistence adapter tests)
+- Docker (optional — only needed to run the adapter integration tests locally; set `DATABASE_URL` to point at a PostgreSQL 13+ instance and run `pnpm vitest run packages/duraflows-pg/tests/integration packages/duraflows-kysely/tests/integration`. Without `DATABASE_URL` these suites are skipped.)
 
 ## Getting Started
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -57,9 +57,9 @@ git checkout -b chore/release-$VERSION
 # Bump root + all packages, re-pin internal deps (mirrors the before:bump hook)
 npm version $VERSION --no-git-tag-version --allow-same-version
 pnpm -r exec npm version $VERSION --no-git-tag-version --allow-same-version
-pnpm --filter @duraflows/pg     exec npm pkg set "dependencies.@duraflows/core=^$VERSION"
-pnpm --filter @duraflows/kysely exec npm pkg set "dependencies.@duraflows/core=^$VERSION"
-pnpm --filter @duraflows/nestjs exec npm pkg set "dependencies.@duraflows/core=^$VERSION"
+pnpm --filter @duraflows/pg     exec npm pkg set "peerDependencies.@duraflows/core=^$VERSION"
+pnpm --filter @duraflows/kysely exec npm pkg set "peerDependencies.@duraflows/core=^$VERSION"
+pnpm --filter @duraflows/nestjs exec npm pkg set "peerDependencies.@duraflows/core=^$VERSION"
 pnpm install --lockfile-only
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,15 +28,15 @@ pnpm add @duraflows/nestjs
 
 You can set up the schema in two ways:
 
-**Option A: Copy the reference migration**
+**Option A: Copy the reference migrations**
 
-The `@duraflows/pg` package ships a reference SQL migration at:
+The `@duraflows/pg` package ships its reference SQL migrations at:
 
 ```
-node_modules/@duraflows/pg/sql/dbmate/001_workflow_core.sql
+node_modules/@duraflows/pg/sql/dbmate/
 ```
 
-Copy it into your migration directory and apply it with your migration tool (dbmate, Flyway, Knex, Prisma, etc.). This migration uses `gen_random_uuid()` (PostgreSQL 13+) for history record UUIDs.
+Copy **all** migration files in that directory and apply them in order with your migration tool (dbmate, Flyway, Knex, Prisma, etc.). Applying only the first migration produces an incomplete schema — the current runtime requires the columns added by the later migrations. The migrations use `gen_random_uuid()` (PostgreSQL 13+) for history record UUIDs.
 
 **Option B: Generate a migration with `generateMigrationSql()`**
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -114,7 +114,7 @@ const { up, down } = generateMigrationSql({ uuidStrategy: "uuidv7" });
 // Paste into your migration file
 ```
 
-A ready-made dbmate migration using `gen_random_uuid()` is also shipped at `sql/dbmate/001_workflow_core.sql`.
+Ready-made dbmate migrations using `gen_random_uuid()` are also shipped under `sql/dbmate/` — apply all of them in order (`001` alone is not sufficient for the current runtime).
 
 ### Guard rejections
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -389,6 +389,16 @@ Each `triggerEvent()` call runs in a single transaction:
 
 If any step fails (including command exceptions), the entire transaction rolls back. No partial state is persisted.
 
+### Context serialization fidelity
+
+`context` and `metadata` are persisted as JSONB via `JSON.stringify`. Only plain JSON survives the round-trip:
+
+- `Date` values are serialized to ISO strings and come back as **strings** — store `ctx.now.toISOString()` explicitly rather than `Date` objects.
+- Keys with `undefined` values are dropped on write and never restored.
+- `bigint`, `Map`, `Set`, class instances, and circular references are not supported (`bigint` throws; the others silently lose data).
+
+Store IDs and primitives, not rich objects.
+
 ## Adapter Conformance Tests
 
 `@duraflows/core` ships a shared conformance suite that any adapter can import to verify it satisfies the cross-adapter contract. The helper is exported from the `@duraflows/core/testing` subpath (a dev-time entry point, not part of the main bundle).

--- a/packages/duraflows-core/package.json
+++ b/packages/duraflows-core/package.json
@@ -61,5 +61,13 @@
   },
   "dependencies": {
     "@camcima/finita": "^3.0.0"
+  },
+  "peerDependencies": {
+    "vitest": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
   }
 }

--- a/packages/duraflows-core/package.json
+++ b/packages/duraflows-core/package.json
@@ -50,8 +50,11 @@
       }
     }
   },
+  "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!dist/**/*.tsbuildinfo",
+    "!dist/**/*.map"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/duraflows-core/src/diagram/mermaid-diagram.ts
+++ b/packages/duraflows-core/src/diagram/mermaid-diagram.ts
@@ -15,6 +15,14 @@ export interface MermaidDiagramOptions {
 
 const INDENT = "    ";
 
+function nodeId(name: string): string {
+  return name.replace(/[^A-Za-z0-9_]/g, "_");
+}
+
+function escapeLabel(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
 export function toMermaidDiagram(definition: WorkflowDefinition, options?: MermaidDiagramOptions): string {
   const opts: Required<MermaidDiagramOptions> = {
     showCommands: false,
@@ -39,7 +47,7 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
   // State node definitions
   lines.push(`${INDENT}_start@{ shape: sm-circ }`);
   for (const stateName of Object.keys(definition.states)) {
-    lines.push(`${INDENT}${stateName}["<b>${stateName}</b>"]:::stateNode`);
+    lines.push(`${INDENT}${nodeId(stateName)}["<b>${escapeLabel(stateName)}</b>"]:::stateNode`);
   }
   const hasTerminals = Object.values(definition.states).some((sd) => isTerminalState(sd));
   if (hasTerminals) {
@@ -48,7 +56,7 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
   lines.push("");
 
   // Start edge
-  lines.push(`${INDENT}_start --> ${definition.initialState}`);
+  lines.push(`${INDENT}_start --> ${nodeId(definition.initialState)}`);
   plainEdgeIndices.push(edgeIndex);
   edgeIndex++;
   lines.push("");
@@ -59,19 +67,19 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
 
     // onEnter
     if (stateDef.onEnter && (stateDef.onEnter.targetState || stateDef.onEnter.errorState)) {
-      const nodeId = `${stateName}__onEnter`;
+      const nId = `${nodeId(stateName)}__onEnter`;
       const label = formatOnEnterNodeLabel(stateDef.onEnter, opts);
-      stateLines.push(`${INDENT}${nodeId}${label}`);
-      stateLines.push(`${INDENT}${stateName} --> ${nodeId}`);
+      stateLines.push(`${INDENT}${nId}${label}`);
+      stateLines.push(`${INDENT}${nodeId(stateName)} --> ${nId}`);
       plainEdgeIndices.push(edgeIndex);
       edgeIndex++;
       if (stateDef.onEnter.targetState) {
-        stateLines.push(`${INDENT}${nodeId} --> ${stateDef.onEnter.targetState}`);
+        stateLines.push(`${INDENT}${nId} --> ${nodeId(stateDef.onEnter.targetState)}`);
         successEdgeIndices.push(edgeIndex);
         edgeIndex++;
       }
       if (stateDef.onEnter.errorState) {
-        stateLines.push(`${INDENT}${nodeId} --> ${stateDef.onEnter.errorState}`);
+        stateLines.push(`${INDENT}${nId} --> ${nodeId(stateDef.onEnter.errorState)}`);
         errorEdgeIndices.push(edgeIndex);
         edgeIndex++;
       }
@@ -81,19 +89,19 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
     if (stateDef.events) {
       for (const [eventName, eventDef] of Object.entries(stateDef.events)) {
         if (!eventDef.targetState && !eventDef.errorState) continue;
-        const nodeId = `${stateName}__${eventName}`;
+        const nId = `${nodeId(stateName)}__${nodeId(eventName)}`;
         const label = formatEventNodeLabel(eventName, eventDef, opts);
-        stateLines.push(`${INDENT}${nodeId}${label}`);
-        stateLines.push(`${INDENT}${stateName} --> ${nodeId}`);
+        stateLines.push(`${INDENT}${nId}${label}`);
+        stateLines.push(`${INDENT}${nodeId(stateName)} --> ${nId}`);
         plainEdgeIndices.push(edgeIndex);
         edgeIndex++;
         if (eventDef.targetState) {
-          stateLines.push(`${INDENT}${nodeId} --> ${eventDef.targetState}`);
+          stateLines.push(`${INDENT}${nId} --> ${nodeId(eventDef.targetState)}`);
           successEdgeIndices.push(edgeIndex);
           edgeIndex++;
         }
         if (eventDef.errorState) {
-          stateLines.push(`${INDENT}${nodeId} --> ${eventDef.errorState}`);
+          stateLines.push(`${INDENT}${nId} --> ${nodeId(eventDef.errorState)}`);
           errorEdgeIndices.push(edgeIndex);
           edgeIndex++;
         }
@@ -110,7 +118,7 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
   if (hasTerminals) {
     for (const [stateName, stateDef] of Object.entries(definition.states)) {
       if (isTerminalState(stateDef)) {
-        lines.push(`${INDENT}${stateName} --> _end`);
+        lines.push(`${INDENT}${nodeId(stateName)} --> _end`);
         plainEdgeIndices.push(edgeIndex);
         edgeIndex++;
       }
@@ -138,14 +146,14 @@ function formatEventNodeLabel(
   eventDef: WorkflowEventDefinition,
   opts: Required<MermaidDiagramOptions>,
 ): string {
-  let label = eventName;
+  let label = escapeLabel(eventName);
 
   if (eventDef.timeout) {
     label += ` ⧖${formatTimeout(eventDef.timeout)}`;
   }
 
   if (opts.showCommands && eventDef.commands && eventDef.commands.length > 0) {
-    const cmdLines = eventDef.commands.map((c) => c.name).join("<br/>");
+    const cmdLines = eventDef.commands.map((c) => escapeLabel(c.name)).join("<br/>");
     label += `<br/><small><i>${cmdLines}</i></small>`;
   }
 
@@ -156,7 +164,7 @@ function formatOnEnterNodeLabel(onEnterDef: WorkflowOnEnterDefinition, opts: Req
   let label = "🗲";
 
   if (opts.showCommands && onEnterDef.commands && onEnterDef.commands.length > 0) {
-    const cmdLines = onEnterDef.commands.map((c) => c.name).join("<br/>");
+    const cmdLines = onEnterDef.commands.map((c) => escapeLabel(c.name)).join("<br/>");
     label += `<br/><small><i>${cmdLines}</i></small>`;
   }
 

--- a/packages/duraflows-core/src/diagram/mermaid-diagram.ts
+++ b/packages/duraflows-core/src/diagram/mermaid-diagram.ts
@@ -15,8 +15,35 @@ export interface MermaidDiagramOptions {
 
 const INDENT = "    ";
 
-function nodeId(name: string): string {
+function sanitizeId(name: string): string {
   return name.replace(/[^A-Za-z0-9_]/g, "_");
+}
+
+/**
+ * Per-diagram node-id allocator. Sanitization is lossy ("a b" and "a_b" both
+ * sanitize to "a_b"), so ids are allocated per logical key with a numeric
+ * suffix on collision — distinct names always get distinct ids, and the same
+ * key always resolves to the same id wherever it is referenced.
+ */
+function createIdAllocator(): (key: string, rawName: string) => string {
+  // _start/_end are synthetic nodes emitted unconditionally — reserve them so
+  // a state that sanitizes to the same token cannot merge with them.
+  const used = new Set(["_start", "_end"]);
+  const byKey = new Map<string, string>();
+  return (key, rawName) => {
+    const existing = byKey.get(key);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const base = sanitizeId(rawName) || "_node";
+    let id = base;
+    for (let n = 2; used.has(id); n++) {
+      id = `${base}_${n}`;
+    }
+    used.add(id);
+    byKey.set(key, id);
+    return id;
+  };
 }
 
 function escapeLabel(text: string): string {
@@ -36,6 +63,9 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
   const errorEdgeIndices: number[] = [];
   let edgeIndex = 0;
 
+  const allocateId = createIdAllocator();
+  const stateId = (name: string): string => allocateId(`state:${name}`, name);
+
   // Header
   lines.push(`flowchart ${opts.direction}`);
   lines.push("");
@@ -47,7 +77,7 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
   // State node definitions
   lines.push(`${INDENT}_start@{ shape: sm-circ }`);
   for (const stateName of Object.keys(definition.states)) {
-    lines.push(`${INDENT}${nodeId(stateName)}["<b>${escapeLabel(stateName)}</b>"]:::stateNode`);
+    lines.push(`${INDENT}${stateId(stateName)}["<b>${escapeLabel(stateName)}</b>"]:::stateNode`);
   }
   const hasTerminals = Object.values(definition.states).some((sd) => isTerminalState(sd));
   if (hasTerminals) {
@@ -56,7 +86,7 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
   lines.push("");
 
   // Start edge
-  lines.push(`${INDENT}_start --> ${nodeId(definition.initialState)}`);
+  lines.push(`${INDENT}_start --> ${stateId(definition.initialState)}`);
   plainEdgeIndices.push(edgeIndex);
   edgeIndex++;
   lines.push("");
@@ -67,19 +97,19 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
 
     // onEnter
     if (stateDef.onEnter && (stateDef.onEnter.targetState || stateDef.onEnter.errorState)) {
-      const nId = `${nodeId(stateName)}__onEnter`;
+      const nId = allocateId(`onEnter:${stateName}`, `${stateId(stateName)}__onEnter`);
       const label = formatOnEnterNodeLabel(stateDef.onEnter, opts);
       stateLines.push(`${INDENT}${nId}${label}`);
-      stateLines.push(`${INDENT}${nodeId(stateName)} --> ${nId}`);
+      stateLines.push(`${INDENT}${stateId(stateName)} --> ${nId}`);
       plainEdgeIndices.push(edgeIndex);
       edgeIndex++;
       if (stateDef.onEnter.targetState) {
-        stateLines.push(`${INDENT}${nId} --> ${nodeId(stateDef.onEnter.targetState)}`);
+        stateLines.push(`${INDENT}${nId} --> ${stateId(stateDef.onEnter.targetState)}`);
         successEdgeIndices.push(edgeIndex);
         edgeIndex++;
       }
       if (stateDef.onEnter.errorState) {
-        stateLines.push(`${INDENT}${nId} --> ${nodeId(stateDef.onEnter.errorState)}`);
+        stateLines.push(`${INDENT}${nId} --> ${stateId(stateDef.onEnter.errorState)}`);
         errorEdgeIndices.push(edgeIndex);
         edgeIndex++;
       }
@@ -89,19 +119,24 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
     if (stateDef.events) {
       for (const [eventName, eventDef] of Object.entries(stateDef.events)) {
         if (!eventDef.targetState && !eventDef.errorState) continue;
-        const nId = `${nodeId(stateName)}__${nodeId(eventName)}`;
+        // The (state, event) pair is JSON-encoded so names containing any
+        // separator character cannot produce ambiguous allocator keys.
+        const nId = allocateId(
+          `event:${JSON.stringify([stateName, eventName])}`,
+          `${stateId(stateName)}__${eventName}`,
+        );
         const label = formatEventNodeLabel(eventName, eventDef, opts);
         stateLines.push(`${INDENT}${nId}${label}`);
-        stateLines.push(`${INDENT}${nodeId(stateName)} --> ${nId}`);
+        stateLines.push(`${INDENT}${stateId(stateName)} --> ${nId}`);
         plainEdgeIndices.push(edgeIndex);
         edgeIndex++;
         if (eventDef.targetState) {
-          stateLines.push(`${INDENT}${nId} --> ${nodeId(eventDef.targetState)}`);
+          stateLines.push(`${INDENT}${nId} --> ${stateId(eventDef.targetState)}`);
           successEdgeIndices.push(edgeIndex);
           edgeIndex++;
         }
         if (eventDef.errorState) {
-          stateLines.push(`${INDENT}${nId} --> ${nodeId(eventDef.errorState)}`);
+          stateLines.push(`${INDENT}${nId} --> ${stateId(eventDef.errorState)}`);
           errorEdgeIndices.push(edgeIndex);
           edgeIndex++;
         }
@@ -118,7 +153,7 @@ export function toMermaidDiagram(definition: WorkflowDefinition, options?: Merma
   if (hasTerminals) {
     for (const [stateName, stateDef] of Object.entries(definition.states)) {
       if (isTerminalState(stateDef)) {
-        lines.push(`${INDENT}${nodeId(stateName)} --> _end`);
+        lines.push(`${INDENT}${stateId(stateName)} --> _end`);
         plainEdgeIndices.push(edgeIndex);
         edgeIndex++;
       }

--- a/packages/duraflows-core/src/errors/index.ts
+++ b/packages/duraflows-core/src/errors/index.ts
@@ -17,6 +17,16 @@ export class WorkflowDefinitionError extends WorkflowError {
   }
 }
 
+export class WorkflowInstanceNotFoundError extends WorkflowError {
+  public readonly workflowInstanceUuid: string;
+
+  constructor(workflowInstanceUuid: string) {
+    super(`Workflow instance "${workflowInstanceUuid}" not found`);
+    this.name = "WorkflowInstanceNotFoundError";
+    this.workflowInstanceUuid = workflowInstanceUuid;
+  }
+}
+
 export class InvalidEventError extends WorkflowError {
   public readonly workflowInstanceUuid: string;
   public readonly currentState: string;

--- a/packages/duraflows-core/src/index.ts
+++ b/packages/duraflows-core/src/index.ts
@@ -39,6 +39,7 @@ export type {
 export {
   WorkflowError,
   WorkflowDefinitionError,
+  WorkflowInstanceNotFoundError,
   InvalidEventError,
   CommandFailureError,
   OnEnterDepthExceededError,

--- a/packages/duraflows-core/src/registry/definition-registry.ts
+++ b/packages/duraflows-core/src/registry/definition-registry.ts
@@ -1,6 +1,10 @@
 import type { WorkflowDefinition } from "../types/definition.js";
 import { WorkflowDefinitionError } from "../errors/index.js";
-import type { WorkflowValidator, WorkflowValidationOptions } from "../validation/workflow-validator.js";
+import type {
+  WorkflowValidator,
+  WorkflowValidationOptions,
+  ValidationError,
+} from "../validation/workflow-validator.js";
 import type { WorkflowCompiler } from "../compilation/workflow-compiler.js";
 import { deepFreeze } from "../util/deep-freeze.js";
 
@@ -14,6 +18,11 @@ export interface InMemoryDefinitionRegistryOptions {
   validator?: WorkflowValidator;
   compiler?: WorkflowCompiler;
   validationOptions?: WorkflowValidationOptions;
+  /**
+   * Called once per non-fatal validation warning (e.g. unreachable states)
+   * at registration time. Without it, warnings are computed and discarded.
+   */
+  onValidationWarning?: (workflowName: string, warning: ValidationError) => void;
 }
 
 export class InMemoryDefinitionRegistry implements WorkflowDefinitionRegistry {
@@ -21,11 +30,13 @@ export class InMemoryDefinitionRegistry implements WorkflowDefinitionRegistry {
   private readonly validator?: WorkflowValidator;
   private readonly compiler?: WorkflowCompiler;
   private readonly validationOptions?: WorkflowValidationOptions;
+  private readonly onValidationWarning?: (workflowName: string, warning: ValidationError) => void;
 
   constructor(options?: InMemoryDefinitionRegistryOptions) {
     this.validator = options?.validator;
     this.compiler = options?.compiler;
     this.validationOptions = options?.validationOptions;
+    this.onValidationWarning = options?.onValidationWarning;
   }
 
   register(definition: WorkflowDefinition): void {
@@ -42,6 +53,11 @@ export class InMemoryDefinitionRegistry implements WorkflowDefinitionRegistry {
           frozen.name,
           `Invalid definition: ${validation.errors.map((e) => e.message).join("; ")}`,
         );
+      }
+      if (this.onValidationWarning) {
+        for (const warning of validation.warnings ?? []) {
+          this.onValidationWarning(frozen.name, warning);
+        }
       }
     }
 

--- a/packages/duraflows-core/src/runtime/workflow-runtime.ts
+++ b/packages/duraflows-core/src/runtime/workflow-runtime.ts
@@ -28,7 +28,7 @@ import { OnEnterExecutor } from "../execution/on-enter-executor.js";
 import { TimeoutResolver } from "../execution/timeout-resolver.js";
 import type { WorkflowCommandRegistry } from "../registry/command-registry.js";
 import type { WorkflowGuardRegistry } from "../registry/guard-registry.js";
-import { WorkflowError } from "../errors/index.js";
+import { WorkflowInstanceNotFoundError } from "../errors/index.js";
 import { WorkflowHandle } from "./workflow-handle.js";
 import type { WorkflowObserver, StateEnterEvent, ObserverErrorHandler } from "../types/observer.js";
 import { ObserverRegistry } from "./observer-registry.js";
@@ -178,7 +178,7 @@ export class WorkflowRuntime {
     const result = await this.transactionRunner.runInTransaction(async () => {
       const instance = await this.instanceStore.lockByUuid(input.workflowInstanceUuid);
       if (!instance) {
-        throw new WorkflowError(`Workflow instance "${input.workflowInstanceUuid}" not found`);
+        throw new WorkflowInstanceNotFoundError(input.workflowInstanceUuid);
       }
 
       const definition = this.definitionRegistry.get(instance.workflowName);
@@ -570,7 +570,7 @@ export class WorkflowRuntime {
   async getAvailableEvents(input: GetAvailableEventsInput): Promise<AvailableWorkflowEvent[]> {
     const instance = await this.instanceStore.findByUuid(input.workflowInstanceUuid);
     if (!instance) {
-      throw new WorkflowError(`Workflow instance "${input.workflowInstanceUuid}" not found`);
+      throw new WorkflowInstanceNotFoundError(input.workflowInstanceUuid);
     }
 
     const definition = this.definitionRegistry.get(instance.workflowName);

--- a/packages/duraflows-core/src/runtime/workflow-runtime.ts
+++ b/packages/duraflows-core/src/runtime/workflow-runtime.ts
@@ -149,7 +149,9 @@ export class WorkflowRuntime {
       return result;
     }
 
-    await this.instanceStore.create(instance);
+    await this.transactionRunner.runInTransaction(async () => {
+      await this.instanceStore.create(instance);
+    });
 
     eventsToFire.push({
       workflowName: instance.workflowName,
@@ -218,7 +220,7 @@ export class WorkflowRuntime {
           outcome: "guard-rejected",
           rejectedBy: eventResult.rejectedBy,
           commandResultsJson: [],
-          triggerMetadata: input.triggerMetadata,
+          triggerMetadata: structuredClone(input.triggerMetadata ?? {}),
         });
 
         return {
@@ -262,7 +264,7 @@ export class WorkflowRuntime {
         outcome: eventResult.outcome,
         errorMessage,
         commandResultsJson: eventResult.commandResults,
-        triggerMetadata: input.triggerMetadata,
+        triggerMetadata: structuredClone(input.triggerMetadata ?? {}),
       });
 
       eventsToFire.push({

--- a/packages/duraflows-core/src/testing/instance-store-conformance.ts
+++ b/packages/duraflows-core/src/testing/instance-store-conformance.ts
@@ -101,6 +101,25 @@ export function runInstanceStoreConformance(label: string, harness: InstanceStor
       }
     });
 
+    it("update with a stale version throws (optimistic locking)", async () => {
+      const { store, transactionRunner, teardown } = await harness.setup();
+      try {
+        const instance = makeInstance();
+        await transactionRunner.runInTransaction(() => store.create(instance));
+
+        // Runtime convention: `version` is pre-incremented before update(),
+        // so adapters match on `version = instance.version - 1`.
+        instance.version = 1;
+        instance.updatedAt = new Date("2026-01-02T00:00:00Z");
+        await transactionRunner.runInTransaction(() => store.update(instance));
+
+        // Re-issuing the same (now stale) version must throw.
+        await expect(transactionRunner.runInTransaction(() => store.update(instance))).rejects.toThrow();
+      } finally {
+        await teardown();
+      }
+    });
+
     it("update does NOT overwrite metadata (metadata is immutable)", async () => {
       const { store, transactionRunner, teardown } = await harness.setup();
       try {
@@ -110,7 +129,10 @@ export function runInstanceStoreConformance(label: string, harness: InstanceStor
         await transactionRunner.runInTransaction(async () => {
           const locked = await store.lockByUuid(instance.uuid);
           expect(locked).not.toBeNull();
-          // Mutate the metadata on the in-memory object — adapters must ignore it
+          // Mutate the metadata on the in-memory object — adapters must ignore it.
+          // Must increment version to satisfy the optimistic-locking contract
+          // (same convention as the runtime: version is pre-incremented before update()).
+          locked!.version = 1;
           locked!.metadata = { tenant: "bob" };
           await store.update(locked!);
         });

--- a/packages/duraflows-core/src/types/persistence.ts
+++ b/packages/duraflows-core/src/types/persistence.ts
@@ -30,9 +30,12 @@ export interface WorkflowInstanceStore {
    * `version`, `context`, `expiresAt`, `lastTransitionAt`, `updatedAt`).
    * `metadata` is immutable and is NOT updated.
    *
-   * Uses optimistic locking: adapters must include `version` in the WHERE
-   * clause and throw `WorkflowError` if no row is matched (concurrent
-   * modification).
+   * Uses optimistic locking. The runtime increments `instance.version`
+   * BEFORE calling this method, so the passed `version` is the NEW value.
+   * Adapters must match on the previous version in the WHERE clause
+   * (`WHERE version = instance.version - 1`), SET `version` to
+   * `instance.version`, and throw `WorkflowError` if no row is matched
+   * (concurrent modification).
    *
    * Transactional: typically inside the same transaction as `lockByUuid`,
    * history appends, and observer-event queuing.
@@ -44,9 +47,12 @@ export interface WorkflowInstanceStore {
    * `now` parameter — not the database clock).
    *
    * **Transactional: REQUIRED.** Must use `SELECT ... FOR UPDATE SKIP LOCKED`
-   * (or equivalent) so multiple workers can safely call this concurrently
-   * without processing the same instance twice. The row locks are held for
-   * the duration of the caller's transaction.
+   * (or equivalent) so concurrently sweeping workers skip rows another
+   * worker is currently scanning. The locks last only as long as the
+   * caller's transaction — the runtime intentionally runs this in a short
+   * transaction and re-locks each instance individually (via `lockByUuid`
+   * plus an `expiresAt` re-check) before processing, so cross-worker
+   * exclusivity comes from that re-lock, not from this scan.
    */
   findExpired(limit: number, now: Date): Promise<WorkflowInstance[]>;
 }

--- a/packages/duraflows-core/src/types/runtime.ts
+++ b/packages/duraflows-core/src/types/runtime.ts
@@ -13,7 +13,8 @@ export interface CommandResult {
 
 export interface WorkflowExecutionContext {
   triggerMetadata: Readonly<Record<string, unknown>>;
-  now: Date;
+  /** Injected clock value for this transition. Treat as immutable — do not call Date mutators on it. */
+  readonly now: Date;
   context: Record<string, unknown>;
   metadata: Readonly<Record<string, unknown>>;
   readonly commandMetadata: Readonly<Record<string, unknown>>;

--- a/packages/duraflows-core/src/util/deep-freeze.ts
+++ b/packages/duraflows-core/src/util/deep-freeze.ts
@@ -8,33 +8,57 @@ const MAP_MUTATORS = ["set", "delete", "clear"] as const;
 const SET_MUTATORS = ["add", "delete", "clear"] as const;
 
 export function deepFreeze<T>(obj: T): Readonly<T> {
-  if (obj === null || typeof obj !== "object" || Object.isFrozen(obj)) {
+  return freezeRecursive(obj, new WeakSet());
+}
+
+function freezeRecursive<T>(obj: T, seen: WeakSet<object>): Readonly<T> {
+  if (obj === null || typeof obj !== "object" || seen.has(obj)) {
+    return obj;
+  }
+  seen.add(obj);
+
+  // Object.freeze does not stop Map/Set mutation (it works on internal slots,
+  // not properties), so the mutator methods are replaced before freezing to
+  // uphold the "mutations throw" contract. Freezing happens BEFORE recursing
+  // into entries so cyclic collections terminate (the `seen` set guards the
+  // re-entry). A Map/Set frozen externally BEFORE reaching deepFreeze cannot
+  // have its mutators replaced (defineProperty on a frozen object throws), so
+  // its entries are frozen best-effort while its own mutators stay callable —
+  // in practice unreachable from the runtime, which always clones via
+  // structuredClone first (clones are never frozen).
+  if (obj instanceof Map) {
+    neutralizeMutators(obj, MAP_MUTATORS, "Map");
+    Object.freeze(obj);
+    for (const [key, value] of obj) {
+      freezeRecursive(key, seen);
+      freezeRecursive(value, seen);
+    }
+    return obj;
+  }
+  if (obj instanceof Set) {
+    neutralizeMutators(obj, SET_MUTATORS, "Set");
+    Object.freeze(obj);
+    for (const value of obj) {
+      freezeRecursive(value, seen);
+    }
     return obj;
   }
 
-  // Object.freeze does not stop Map/Set mutation (it works on internal
-  // slots, not properties), so replace the mutator methods before freezing
-  // to uphold the "mutations throw" contract.
-  if (obj instanceof Map) {
-    for (const [key, value] of obj) {
-      deepFreeze(key);
-      deepFreeze(value);
-    }
-    for (const method of MAP_MUTATORS) {
-      Object.defineProperty(obj, method, { value: throwMutation("Map") });
-    }
-  } else if (obj instanceof Set) {
-    for (const value of obj) {
-      deepFreeze(value);
-    }
-    for (const method of SET_MUTATORS) {
-      Object.defineProperty(obj, method, { value: throwMutation("Set") });
-    }
+  if (Object.isFrozen(obj)) {
+    return obj;
   }
-
   Object.freeze(obj);
   for (const value of Object.values(obj as Record<string, unknown>)) {
-    deepFreeze(value);
+    freezeRecursive(value, seen);
   }
   return obj;
+}
+
+function neutralizeMutators(obj: object, methods: readonly string[], typeName: string): void {
+  if (Object.isFrozen(obj) || Object.getOwnPropertyDescriptor(obj, methods[0])) {
+    return;
+  }
+  for (const method of methods) {
+    Object.defineProperty(obj, method, { value: throwMutation(typeName) });
+  }
 }

--- a/packages/duraflows-core/src/util/deep-freeze.ts
+++ b/packages/duraflows-core/src/util/deep-freeze.ts
@@ -1,7 +1,37 @@
+function throwMutation(type: string): () => never {
+  return () => {
+    throw new TypeError(`Cannot mutate a frozen ${type} inside a workflow execution context`);
+  };
+}
+
+const MAP_MUTATORS = ["set", "delete", "clear"] as const;
+const SET_MUTATORS = ["add", "delete", "clear"] as const;
+
 export function deepFreeze<T>(obj: T): Readonly<T> {
   if (obj === null || typeof obj !== "object" || Object.isFrozen(obj)) {
     return obj;
   }
+
+  // Object.freeze does not stop Map/Set mutation (it works on internal
+  // slots, not properties), so replace the mutator methods before freezing
+  // to uphold the "mutations throw" contract.
+  if (obj instanceof Map) {
+    for (const [key, value] of obj) {
+      deepFreeze(key);
+      deepFreeze(value);
+    }
+    for (const method of MAP_MUTATORS) {
+      Object.defineProperty(obj, method, { value: throwMutation("Map") });
+    }
+  } else if (obj instanceof Set) {
+    for (const value of obj) {
+      deepFreeze(value);
+    }
+    for (const method of SET_MUTATORS) {
+      Object.defineProperty(obj, method, { value: throwMutation("Set") });
+    }
+  }
+
   Object.freeze(obj);
   for (const value of Object.values(obj as Record<string, unknown>)) {
     deepFreeze(value);

--- a/packages/duraflows-core/src/validation/workflow-validator.ts
+++ b/packages/duraflows-core/src/validation/workflow-validator.ts
@@ -8,6 +8,7 @@ export interface ValidationError {
 export interface ValidationResult {
   valid: boolean;
   errors: ValidationError[];
+  warnings?: ValidationError[];
 }
 
 export interface WorkflowValidationOptions {
@@ -18,6 +19,7 @@ export interface WorkflowValidationOptions {
 export class WorkflowValidator {
   validate(definition: WorkflowDefinition, options?: WorkflowValidationOptions): ValidationResult {
     const errors: ValidationError[] = [];
+    const warnings: ValidationError[] = [];
 
     if (!definition.name || definition.name.trim() === "") {
       errors.push({ path: "name", message: "Workflow name must be non-empty" });
@@ -140,7 +142,36 @@ export class WorkflowValidator {
     // Validate onEnter cycles
     this.validateOnEnterCycles(definition, errors);
 
-    return { valid: errors.length === 0, errors };
+    // Reachability pass: warn about states unreachable from the initial state
+    if (definition.states[definition.initialState]) {
+      const reachable = new Set<string>([definition.initialState]);
+      const queue = [definition.initialState];
+      while (queue.length > 0) {
+        const current = queue.shift()!;
+        const state = definition.states[current];
+        if (!state) continue;
+        const targets: (string | undefined)[] = [state.onEnter?.targetState, state.onEnter?.errorState];
+        for (const event of Object.values(state.events ?? {})) {
+          targets.push(event.targetState, event.errorState);
+        }
+        for (const target of targets) {
+          if (target && definition.states[target] && !reachable.has(target)) {
+            reachable.add(target);
+            queue.push(target);
+          }
+        }
+      }
+      for (const stateName of stateNames) {
+        if (!reachable.has(stateName)) {
+          warnings.push({
+            path: `states.${stateName}`,
+            message: `State "${stateName}" is unreachable from initial state "${definition.initialState}"`,
+          });
+        }
+      }
+    }
+
+    return { valid: errors.length === 0, errors, warnings };
   }
 
   private validateOnEnterCycles(definition: WorkflowDefinition, errors: ValidationError[]): void {

--- a/packages/duraflows-core/tests/integration/instance-store-conformance.test.ts
+++ b/packages/duraflows-core/tests/integration/instance-store-conformance.test.ts
@@ -4,14 +4,8 @@
  * core integration tests. This both demonstrates the helper and ensures it
  * stays in sync with the interface.
  */
-import { randomUUID } from "node:crypto";
 import { runInstanceStoreConformance } from "../../src/testing/index.js";
-import type {
-  WorkflowInstanceStore,
-  WorkflowHistoryStore,
-  WorkflowHistoryRecord,
-  WorkflowTransactionRunner,
-} from "../../src/types/persistence.js";
+import type { WorkflowInstanceStore, WorkflowTransactionRunner } from "../../src/types/persistence.js";
 import type { WorkflowInstance } from "../../src/types/runtime.js";
 
 // ---------------------------------------------------------------------------
@@ -37,7 +31,11 @@ class InMemoryInstanceStore implements WorkflowInstanceStore {
 
   async update(instance: WorkflowInstance): Promise<void> {
     const existing = this.instances.get(instance.uuid);
-    if (!existing) return;
+    // Optimistic locking: the runtime pre-increments `version`, so the stored
+    // row must be at `instance.version - 1` for the update to apply.
+    if (!existing || existing.version !== instance.version - 1) {
+      throw new Error(`Optimistic locking failure: workflow instance "${instance.uuid}" was modified concurrently`);
+    }
     // Metadata is immutable — restore it from the stored record
     this.instances.set(instance.uuid, structuredClone({ ...instance, metadata: existing.metadata }));
   }
@@ -51,26 +49,6 @@ class InMemoryInstanceStore implements WorkflowInstanceStore {
       }
     }
     return results;
-  }
-}
-
-class InMemoryHistoryStore implements WorkflowHistoryStore {
-  private readonly records: Array<WorkflowHistoryRecord & { uuid: string }> = [];
-
-  async append(entry: WorkflowHistoryRecord): Promise<string> {
-    const uuid = randomUUID();
-    this.records.push({ ...entry, uuid });
-    return uuid;
-  }
-
-  async findByInstanceUuid(
-    workflowInstanceUuid: string,
-    options?: { limit?: number; offset?: number },
-  ): Promise<WorkflowHistoryRecord[]> {
-    const matching = this.records.filter((r) => r.workflowInstanceUuid === workflowInstanceUuid);
-    const offset = options?.offset ?? 0;
-    const limit = options?.limit ?? matching.length;
-    return matching.slice(offset, offset + limit);
   }
 }
 

--- a/packages/duraflows-core/tests/integration/workflow-runtime-events.test.ts
+++ b/packages/duraflows-core/tests/integration/workflow-runtime-events.test.ts
@@ -593,4 +593,41 @@ describe("WorkflowRuntime.getAvailableEvents", () => {
     const stored = await instanceStore.findByUuid(instance.uuid);
     expect(stored!.currentState).toBe("active");
   });
+
+  it("event failure with a bare {ok:false} result records the fallback error message", async () => {
+    const definition: WorkflowDefinition = {
+      name: "bare-failure-event",
+      initialState: "draft",
+      states: {
+        draft: {
+          events: {
+            submit: {
+              targetState: "submitted",
+              errorState: "failed",
+              commands: [{ name: "bareFail" }],
+            },
+          },
+        },
+        submitted: {},
+        failed: {},
+      },
+    };
+    definitionRegistry.register(definition);
+
+    // Bare failure: no message, no code — exercises the "Command failed" fallback.
+    commandRegistry.register("bareFail", {
+      execute: async () => ({ ok: false }),
+    });
+
+    const instance = await runtime.createInstance({ workflowName: "bare-failure-event" });
+    const result = await runtime.triggerEvent({ workflowInstanceUuid: instance.uuid, eventName: "submit" });
+
+    expect(result.outcome).toBe("failure");
+    expect(result.toState).toBe("failed");
+
+    const history = await runtime.getHistory(instance.uuid);
+    expect(history).toHaveLength(1);
+    expect(history[0].outcome).toBe("failure");
+    expect(history[0].errorMessage).toBe("Command failed");
+  });
 });

--- a/packages/duraflows-core/tests/integration/workflow-runtime-on-enter.test.ts
+++ b/packages/duraflows-core/tests/integration/workflow-runtime-on-enter.test.ts
@@ -1184,4 +1184,278 @@ describe("WorkflowRuntime onEnter integration", () => {
 
     expect((sharedDefinition.states.processing.context!.policy as { retries: number }).retries).toBe(3);
   });
+
+  it("processExpiredWorkflows routes a mandatory timeout-command failure to errorState with the fallback error message", async () => {
+    const definition: WorkflowDefinition = {
+      name: "timeout-error-route",
+      initialState: "waiting",
+      states: {
+        waiting: {
+          events: {
+            expire: {
+              targetState: "expired",
+              errorState: "expireFailed",
+              timeout: { afterMinutes: 30 },
+              commands: [{ name: "bareFail" }],
+            },
+          },
+        },
+        expired: {},
+        expireFailed: {},
+      },
+    };
+
+    definitionRegistry.register(definition);
+    // Bare failure: no message, no code — exercises the "Command failed" fallback.
+    commandRegistry.register("bareFail", {
+      execute: async () => ({ ok: false }),
+    });
+
+    const instance = await runtime.createInstance({ workflowName: "timeout-error-route" });
+
+    // Force expiration in the past.
+    const stored = await instanceStore.findByUuid(instance.uuid);
+    stored!.expiresAt = new Date("2025-06-15T11:00:00.000Z");
+    await instanceStore.update(stored!);
+
+    const result = await runtime.processExpiredWorkflows();
+    expect(result.processed).toBe(1);
+    expect(result.failed).toHaveLength(0);
+
+    // The instance moved to the errorState, not the targetState.
+    const updated = await instanceStore.findByUuid(instance.uuid);
+    expect(updated!.currentState).toBe("expireFailed");
+
+    const history = await historyStore.findByInstanceUuid(instance.uuid);
+    expect(history).toHaveLength(1);
+    expect(history[0].eventName).toBe("expire");
+    expect(history[0].fromState).toBe("waiting");
+    expect(history[0].toState).toBe("expireFailed");
+    expect(history[0].outcome).toBe("failure");
+    expect(history[0].errorMessage).toBe("Command failed");
+  });
+
+  it("processExpiredWorkflows skips an instance that disappeared between scan and re-lock", async () => {
+    const definition: WorkflowDefinition = {
+      name: "vanished-between-scan-and-lock",
+      initialState: "waiting",
+      states: {
+        waiting: {
+          events: {
+            expire: {
+              targetState: "expired",
+              timeout: { afterMinutes: 30 },
+            },
+          },
+        },
+        expired: {},
+      },
+    };
+
+    definitionRegistry.register(definition);
+
+    const instance = await runtime.createInstance({ workflowName: "vanished-between-scan-and-lock" });
+
+    const stored = await instanceStore.findByUuid(instance.uuid);
+    stored!.expiresAt = new Date("2025-06-15T11:00:00.000Z");
+    await instanceStore.update(stored!);
+
+    // Simulate: instance deleted by another worker between findExpired and lockByUuid.
+    const lockSpy = vi.spyOn(instanceStore, "lockByUuid").mockResolvedValueOnce(null);
+
+    const result = await runtime.processExpiredWorkflows();
+
+    expect(result).toEqual({ processed: 0, rejected: 0, failed: [] });
+
+    // Nothing was transitioned or recorded.
+    const history = await historyStore.findByInstanceUuid(instance.uuid);
+    expect(history).toHaveLength(0);
+
+    lockSpy.mockRestore();
+  });
+
+  it("processExpiredWorkflows skips an instance that is no longer expired at re-lock", async () => {
+    const definition: WorkflowDefinition = {
+      name: "deadline-pushed-out-at-relock",
+      initialState: "waiting",
+      states: {
+        waiting: {
+          events: {
+            expire: {
+              targetState: "expired",
+              timeout: { afterMinutes: 30 },
+            },
+          },
+        },
+        expired: {},
+      },
+    };
+
+    definitionRegistry.register(definition);
+
+    const instance = await runtime.createInstance({ workflowName: "deadline-pushed-out-at-relock" });
+
+    const stored = await instanceStore.findByUuid(instance.uuid);
+    stored!.expiresAt = new Date("2025-06-15T11:00:00.000Z");
+    await instanceStore.update(stored!);
+
+    // Simulate: another worker pushed the deadline into the future between scan and re-lock.
+    const originalLock = instanceStore.lockByUuid.bind(instanceStore);
+    const lockSpy = vi.spyOn(instanceStore, "lockByUuid");
+    lockSpy.mockImplementationOnce(async (uuid: string) => {
+      const row = await originalLock(uuid);
+      if (row) {
+        row.expiresAt = new Date("2025-06-15T13:00:00.000Z"); // future vs fixed clock 12:00
+      }
+      return row;
+    });
+
+    const result = await runtime.processExpiredWorkflows();
+
+    expect(result.processed).toBe(0);
+    expect(result.failed).toHaveLength(0);
+
+    // Instance untouched: still waiting, no history.
+    const final = await instanceStore.findByUuid(instance.uuid);
+    expect(final!.currentState).toBe("waiting");
+    const history = await historyStore.findByInstanceUuid(instance.uuid);
+    expect(history).toHaveLength(0);
+
+    lockSpy.mockRestore();
+  });
+
+  it("processExpiredWorkflows records a non-Error throw as a failed instance via String(error)", async () => {
+    const definition: WorkflowDefinition = {
+      name: "non-error-throw",
+      initialState: "waiting",
+      states: {
+        waiting: {
+          events: {
+            expire: {
+              targetState: "expired",
+              timeout: { afterMinutes: 30 },
+            },
+          },
+        },
+        expired: {},
+      },
+    };
+
+    definitionRegistry.register(definition);
+
+    const instance = await runtime.createInstance({ workflowName: "non-error-throw" });
+
+    const stored = await instanceStore.findByUuid(instance.uuid);
+    stored!.expiresAt = new Date("2025-06-15T11:00:00.000Z");
+    await instanceStore.update(stored!);
+
+    // Re-lock throws a plain string (not an Error instance).
+    const lockSpy = vi.spyOn(instanceStore, "lockByUuid").mockRejectedValueOnce("boom");
+
+    const result = await runtime.processExpiredWorkflows();
+
+    expect(result.processed).toBe(0);
+    expect(result.failed).toEqual([{ uuid: instance.uuid, error: "boom" }]);
+
+    lockSpy.mockRestore();
+  });
+
+  it("processExpiredWorkflows handles a timeout event without targetState — instance stays in current state", async () => {
+    const definition: WorkflowDefinition = {
+      name: "timeout-no-target",
+      initialState: "waiting",
+      states: {
+        waiting: {
+          events: {
+            heartbeat: {
+              // No targetState: prospectiveToState falls back to the current state.
+              timeout: { afterMinutes: 30 },
+              commands: [{ name: "recordHeartbeat" }],
+            },
+          },
+        },
+      },
+    };
+
+    definitionRegistry.register(definition);
+
+    let captured: WorkflowExecutionContext | undefined;
+    commandRegistry.register("recordHeartbeat", {
+      execute: async (_subject, ctx) => {
+        captured = ctx;
+        return { ok: true };
+      },
+    });
+
+    const instance = await runtime.createInstance({ workflowName: "timeout-no-target" });
+
+    const stored = await instanceStore.findByUuid(instance.uuid);
+    stored!.expiresAt = new Date("2025-06-15T11:00:00.000Z");
+    await instanceStore.update(stored!);
+
+    const result = await runtime.processExpiredWorkflows();
+    expect(result.processed).toBe(1);
+    expect(result.failed).toHaveLength(0);
+
+    // prospectiveToState fell back to the current state.
+    expect(captured).toBeDefined();
+    expect(captured!.toState).toBe("waiting");
+
+    // On success with no targetState the instance stays where it was.
+    const final = await instanceStore.findByUuid(instance.uuid);
+    expect(final!.currentState).toBe("waiting");
+
+    const history = await historyStore.findByInstanceUuid(instance.uuid);
+    expect(history).toHaveLength(1);
+    expect(history[0].eventName).toBe("heartbeat");
+    expect(history[0].fromState).toBe("waiting");
+    expect(history[0].toState).toBe("waiting");
+    expect(history[0].outcome).toBe("success");
+  });
+
+  it("onEnter hop failure with a bare {ok:false} result records the fallback error message", async () => {
+    const definition: WorkflowDefinition = {
+      name: "on-enter-bare-failure",
+      initialState: "draft",
+      states: {
+        draft: {
+          events: {
+            process: { targetState: "processing" },
+          },
+        },
+        processing: {
+          onEnter: {
+            targetState: "done",
+            errorState: "failed",
+            commands: [{ name: "bareFailOnEnter" }],
+          },
+        },
+        done: {},
+        failed: {},
+      },
+    };
+
+    definitionRegistry.register(definition);
+    // Bare failure: no message, no code — exercises the "Command failed" fallback.
+    commandRegistry.register("bareFailOnEnter", {
+      execute: async () => ({ ok: false }),
+    });
+
+    const instance = await runtime.createInstance({ workflowName: "on-enter-bare-failure" });
+
+    const result = await runtime.triggerEvent({
+      workflowInstanceUuid: instance.uuid,
+      eventName: "process",
+    });
+
+    expect(result.outcome).toBe("failure");
+    expect(result.toState).toBe("failed");
+
+    const history = await historyStore.findByInstanceUuid(instance.uuid);
+    expect(history).toHaveLength(2);
+    expect(history[1].eventName).toBe("onEnter");
+    expect(history[1].toState).toBe("failed");
+    expect(history[1].outcome).toBe("failure");
+    expect(history[1].errorMessage).toBe("Command failed");
+  });
 });

--- a/packages/duraflows-core/tests/unit/deep-freeze.test.ts
+++ b/packages/duraflows-core/tests/unit/deep-freeze.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { deepFreeze } from "../../src/util/deep-freeze.js";
+
+describe("deepFreeze", () => {
+  it("freezes plain objects so mutation throws in strict mode", () => {
+    const obj = deepFreeze({ a: 1 });
+    expect(() => {
+      (obj as { a: number }).a = 2;
+    }).toThrow(TypeError);
+  });
+
+  it("freezes nested objects and arrays", () => {
+    const obj = deepFreeze({ nested: { list: [{ x: 1 }] } });
+    expect(() => {
+      (obj.nested.list[0] as { x: number }).x = 2;
+    }).toThrow(TypeError);
+    expect(() => {
+      (obj.nested.list as unknown[]).push({});
+    }).toThrow(TypeError);
+  });
+
+  it("makes Map.set/delete/clear throw", () => {
+    const map = new Map([["k", { v: 1 }]]);
+    const frozen = deepFreeze({ map }).map;
+    expect(() => frozen.set("k2", { v: 2 })).toThrow(TypeError);
+    expect(() => frozen.delete("k")).toThrow(TypeError);
+    expect(() => frozen.clear()).toThrow(TypeError);
+  });
+
+  it("makes Set.add/delete/clear throw", () => {
+    const set = new Set([1, 2]);
+    const frozen = deepFreeze({ set }).set;
+    expect(() => frozen.add(3)).toThrow(TypeError);
+    expect(() => frozen.delete(1)).toThrow(TypeError);
+    expect(() => frozen.clear()).toThrow(TypeError);
+  });
+
+  it("deep-freezes objects held inside Map values and Set members", () => {
+    const map = new Map([["k", { v: 1 }]]);
+    const set = new Set([{ s: 1 }]);
+    deepFreeze({ map, set });
+    expect(() => {
+      map.get("k")!.v = 2;
+    }).toThrow(TypeError);
+    const member = set.values().next().value!;
+    expect(() => {
+      member.s = 2;
+    }).toThrow(TypeError);
+  });
+
+  it("handles null, primitives, and already-frozen objects", () => {
+    expect(deepFreeze(null)).toBeNull();
+    expect(deepFreeze(42)).toBe(42);
+    const pre = Object.freeze({ a: 1 });
+    expect(deepFreeze(pre)).toBe(pre);
+  });
+});

--- a/packages/duraflows-core/tests/unit/deep-freeze.test.ts
+++ b/packages/duraflows-core/tests/unit/deep-freeze.test.ts
@@ -54,4 +54,52 @@ describe("deepFreeze", () => {
     const pre = Object.freeze({ a: 1 });
     expect(deepFreeze(pre)).toBe(pre);
   });
+
+  it("handles cyclic Maps and Sets without stack overflow", () => {
+    const map = new Map<string, unknown>();
+    map.set("self", map);
+    const set = new Set<unknown>();
+    set.add(set);
+    expect(() => deepFreeze({ map, set })).not.toThrow();
+    expect(() => map.set("x", 1)).toThrow(TypeError);
+    expect(() => set.add(1)).toThrow(TypeError);
+  });
+
+  it("handles mutually-referencing Maps without stack overflow", () => {
+    const a = new Map<string, unknown>();
+    const b = new Map<string, unknown>();
+    a.set("b", b);
+    b.set("a", a);
+    expect(() => deepFreeze(a)).not.toThrow();
+    expect(() => b.set("x", 1)).toThrow(TypeError);
+  });
+
+  it("handles cycles through plain objects into collections", () => {
+    const root: Record<string, unknown> = {};
+    const map = new Map<string, unknown>([["root", root]]);
+    root.map = map;
+    expect(() => deepFreeze(root)).not.toThrow();
+    expect(() => map.set("x", 1)).toThrow(TypeError);
+    expect(Object.isFrozen(root)).toBe(true);
+  });
+
+  it("is idempotent when called twice on the same Map", () => {
+    const map = new Map([["k", 1]]);
+    deepFreeze(map);
+    expect(() => deepFreeze(map)).not.toThrow();
+    expect(() => map.set("x", 2)).toThrow(TypeError);
+  });
+
+  it("freezes entries of an externally pre-frozen Map without crashing (best effort)", () => {
+    const entry = { v: 1 };
+    const map = new Map([["k", entry]]);
+    Object.freeze(map);
+    expect(() => deepFreeze({ map })).not.toThrow();
+    // Entries are still frozen; the frozen Map's own mutators cannot be
+    // replaced (defineProperty on a frozen object throws) — documented
+    // limitation, unreachable via the runtime's structuredClone call sites.
+    expect(() => {
+      entry.v = 2;
+    }).toThrow(TypeError);
+  });
 });

--- a/packages/duraflows-core/tests/unit/errors.test.ts
+++ b/packages/duraflows-core/tests/unit/errors.test.ts
@@ -5,6 +5,7 @@ import {
   InvalidEventError,
   OnEnterDepthExceededError,
   CommandFailureError,
+  WorkflowInstanceNotFoundError,
 } from "../../src/errors/index.js";
 
 describe("WorkflowError", () => {
@@ -103,5 +104,15 @@ describe("CommandFailureError", () => {
   it("extends WorkflowError", () => {
     const err = new CommandFailureError("u", "e", "c", { ok: false });
     expect(err).toBeInstanceOf(WorkflowError);
+  });
+});
+
+describe("WorkflowInstanceNotFoundError", () => {
+  it("extends WorkflowError and carries the instance uuid", () => {
+    const err = new WorkflowInstanceNotFoundError("abc-123");
+    expect(err).toBeInstanceOf(WorkflowError);
+    expect(err.name).toBe("WorkflowInstanceNotFoundError");
+    expect(err.workflowInstanceUuid).toBe("abc-123");
+    expect(err.message).toBe('Workflow instance "abc-123" not found');
   });
 });

--- a/packages/duraflows-core/tests/unit/mermaid-diagram.test.ts
+++ b/packages/duraflows-core/tests/unit/mermaid-diagram.test.ts
@@ -516,3 +516,57 @@ describe("state with both events and onEnter", () => {
     expect(autoIdx).toBeLessThan(skipIdx);
   });
 });
+
+describe("node id collisions", () => {
+  it("keeps distinct ids for names that sanitize identically", () => {
+    const def: WorkflowDefinition = {
+      name: "wf",
+      initialState: "a b",
+      states: {
+        "a b": { events: { go: { targetState: "a_b" } } },
+        a_b: {},
+      },
+    };
+    const diagram = toMermaidDiagram(def);
+    // Both states get their own node definitions with distinct ids.
+    expect(diagram).toContain('a_b["<b>a b</b>"]');
+    expect(diagram).toContain('a_b_2["<b>a_b</b>"]');
+    // The transition must point at the second state's id, not the first's.
+    expect(diagram).toContain("a_b__go --> a_b_2");
+  });
+
+  it("does not collide with the synthetic _start and _end nodes", () => {
+    const def: WorkflowDefinition = {
+      name: "wf",
+      initialState: "*start",
+      states: {
+        "*start": { events: { finish: { targetState: "-end" } } },
+        "-end": {},
+      },
+    };
+    const diagram = toMermaidDiagram(def);
+    // "*start" sanitizes to "_start" (reserved) and "-end" to "_end" (reserved),
+    // so both must receive suffixed ids.
+    expect(diagram).toContain('_start_2["<b>*start</b>"]');
+    expect(diagram).toContain('_end_2["<b>-end</b>"]');
+    expect(diagram).toContain("_start --> _start_2");
+    expect(diagram).toContain("_end_2 --> _end");
+  });
+
+  it("disambiguates event nodes whose joined ids would collide", () => {
+    const def: WorkflowDefinition = {
+      name: "wf",
+      initialState: "a",
+      states: {
+        a: { events: { b__c: { targetState: "done" } } },
+        a__b: { events: { c: { targetState: "done" } } },
+        done: {},
+      },
+    };
+    const diagram = toMermaidDiagram(def);
+    // state "a" + event "b__c" and state "a__b" + event "c" both join to
+    // "a__b__c" — the allocator must keep them distinct.
+    expect(diagram).toContain("a --> a__b__c");
+    expect(diagram).toContain("a__b --> a__b__c_2");
+  });
+});

--- a/packages/duraflows-core/tests/unit/mermaid-diagram.test.ts
+++ b/packages/duraflows-core/tests/unit/mermaid-diagram.test.ts
@@ -517,6 +517,59 @@ describe("state with both events and onEnter", () => {
   });
 });
 
+describe("fallback and edge cases", () => {
+  it("uses the _node fallback id for a state name that sanitizes to empty", () => {
+    const def: WorkflowDefinition = {
+      name: "wf",
+      initialState: "",
+      states: {
+        "": {},
+      },
+    };
+    const diagram = toMermaidDiagram(def);
+    // The empty state name sanitizes to "" — the allocator falls back to "_node".
+    expect(diagram).toContain('_node["<b></b>"]:::stateNode');
+    expect(diagram).toContain("_start --> _node");
+  });
+
+  it("emits no _end node when the workflow has no terminal states", () => {
+    const def: WorkflowDefinition = {
+      name: "ping-pong",
+      initialState: "a",
+      states: {
+        a: { events: { go: { targetState: "b" } } },
+        b: { events: { back: { targetState: "a" } } },
+      },
+    };
+    const diagram = toMermaidDiagram(def);
+    expect(diagram).not.toContain("_end@");
+    expect(diagram).not.toContain("--> _end");
+  });
+
+  it("renders onEnter with only errorState — error edge but no success edge", () => {
+    const def: WorkflowDefinition = {
+      name: "on-enter-error-only",
+      initialState: "a",
+      states: {
+        a: {
+          onEnter: {
+            errorState: "err",
+            commands: [{ name: "mayFail" }],
+          },
+        },
+        err: {},
+      },
+    };
+    const diagram = toMermaidDiagram(def);
+    expect(diagram).toContain('a__onEnter(["🗲"])');
+    expect(diagram).toContain("a --> a__onEnter");
+    expect(diagram).toContain("a__onEnter --> err");
+    // The only colored edge is the error edge — no success edge exists.
+    expect(diagram).toContain("stroke:#dc3545");
+    expect(diagram).not.toContain("stroke:#22c55e");
+  });
+});
+
 describe("node id collisions", () => {
   it("keeps distinct ids for names that sanitize identically", () => {
     const def: WorkflowDefinition = {

--- a/packages/duraflows-core/tests/unit/mermaid-diagram.test.ts
+++ b/packages/duraflows-core/tests/unit/mermaid-diagram.test.ts
@@ -450,6 +450,50 @@ describe("node shapes", () => {
   });
 });
 
+describe("special characters in names", () => {
+  it("sanitizes node ids and escapes labels", () => {
+    const diagram = toMermaidDiagram({
+      name: "wf",
+      initialState: "draft <v1>",
+      states: {
+        "draft <v1>": { events: { 'approve "fast"': { targetState: "done" } } },
+        done: {},
+      },
+    });
+    // Labels must be HTML-escaped
+    expect(diagram).toContain("draft &lt;v1&gt;");
+    expect(diagram).toContain("approve &quot;fast&quot;");
+    // Raw unescaped forms must NOT appear in label text
+    expect(diagram).not.toContain("<b>draft <v1></b>");
+    // Node ids must be sanitized to [A-Za-z0-9_] — the raw state name with
+    // spaces/angle brackets must never appear as a bare node id token.
+    expect(diagram).not.toMatch(/(^|\s)draft <v1>(\[|__| -->)/);
+  });
+
+  it("escapes command names containing special characters when showCommands is enabled", () => {
+    const diagram = toMermaidDiagram(
+      {
+        name: "wf",
+        initialState: "a",
+        states: {
+          a: {
+            events: {
+              Go: {
+                targetState: "b",
+                commands: [{ name: 'send<email>"now"' }],
+              },
+            },
+          },
+          b: {},
+        },
+      },
+      { showCommands: true },
+    );
+    expect(diagram).toContain("send&lt;email&gt;&quot;now&quot;");
+    expect(diagram).not.toContain('send<email>"now"');
+  });
+});
+
 describe("state with both events and onEnter", () => {
   it("emits onEnter node before event nodes", () => {
     const def: WorkflowDefinition = {

--- a/packages/duraflows-core/tests/unit/on-enter-executor.test.ts
+++ b/packages/duraflows-core/tests/unit/on-enter-executor.test.ts
@@ -628,4 +628,37 @@ describe("OnEnterExecutor", () => {
     expect(result.hops).toHaveLength(1);
     expect(result.hops[0].transitionUuid).toBe(callerUuid);
   });
+
+  it("onEnter with no commands and no targetState completes without recording a hop", async () => {
+    const definition: WorkflowDefinition = {
+      name: "test-wf",
+      initialState: "processing",
+      states: {
+        processing: {
+          // Constructible and valid: all WorkflowOnEnterDefinition fields are
+          // optional and the validator imposes no "must do something" rule on
+          // onEnter (unlike events). No commands -> empty commandResults ->
+          // no hop is recorded.
+          onEnter: {},
+        },
+      },
+    };
+
+    const registry = makeRegistry({});
+    const commandExecutor = new CommandExecutor(registry);
+    const executor = new OnEnterExecutor(commandExecutor);
+
+    const result = await executor.executeChain(
+      definition,
+      "processing",
+      "instance-empty",
+      undefined,
+      makeContext(),
+      10,
+    );
+
+    expect(result.finalState).toBe("processing");
+    expect(result.outcome).toBe("success");
+    expect(result.hops).toHaveLength(0);
+  });
 });

--- a/packages/duraflows-core/tests/unit/registries.test.ts
+++ b/packages/duraflows-core/tests/unit/registries.test.ts
@@ -284,6 +284,16 @@ describe("InMemoryDefinitionRegistry onValidationWarning", () => {
     expect(onValidationWarning).not.toHaveBeenCalled();
   });
 
+  it("does not invoke the callback when the validator omits the warnings field entirely", () => {
+    // `warnings` is optional on ValidationResult — registration must tolerate
+    // its absence via the `?? []` fallback.
+    const mockValidator = { validate: vi.fn().mockReturnValue({ valid: true, errors: [] }) };
+    const onValidationWarning = vi.fn();
+    const registry = new InMemoryDefinitionRegistry({ validator: mockValidator, onValidationWarning });
+    expect(() => registry.register(minimalDefinition)).not.toThrow();
+    expect(onValidationWarning).not.toHaveBeenCalled();
+  });
+
   it("surfaces real unreachable-state warnings end-to-end with the actual validator", async () => {
     const { WorkflowValidator } = await import("../../src/validation/workflow-validator.js");
     const warnings: string[] = [];

--- a/packages/duraflows-core/tests/unit/registries.test.ts
+++ b/packages/duraflows-core/tests/unit/registries.test.ts
@@ -257,3 +257,45 @@ describe("InMemoryDefinitionRegistry", () => {
     expect(Object.isFrozen(stored.states.ready.context!.nested)).toBe(true);
   });
 });
+
+describe("InMemoryDefinitionRegistry onValidationWarning", () => {
+  it("invokes the callback once per validator warning", () => {
+    const mockValidator = {
+      validate: vi.fn().mockReturnValue({
+        valid: true,
+        errors: [],
+        warnings: [{ path: "states.orphan", message: 'State "orphan" is unreachable from initial state "start"' }],
+      }),
+    };
+    const received: Array<{ name: string; path: string }> = [];
+    const registry = new InMemoryDefinitionRegistry({
+      validator: mockValidator,
+      onValidationWarning: (name, warning) => received.push({ name, path: warning.path }),
+    });
+    registry.register(minimalDefinition);
+    expect(received).toEqual([{ name: "test-wf", path: "states.orphan" }]);
+  });
+
+  it("does not invoke the callback when there are no warnings", () => {
+    const mockValidator = { validate: vi.fn().mockReturnValue({ valid: true, errors: [], warnings: [] }) };
+    const onValidationWarning = vi.fn();
+    const registry = new InMemoryDefinitionRegistry({ validator: mockValidator, onValidationWarning });
+    registry.register(minimalDefinition);
+    expect(onValidationWarning).not.toHaveBeenCalled();
+  });
+
+  it("surfaces real unreachable-state warnings end-to-end with the actual validator", async () => {
+    const { WorkflowValidator } = await import("../../src/validation/workflow-validator.js");
+    const warnings: string[] = [];
+    const registry = new InMemoryDefinitionRegistry({
+      validator: new WorkflowValidator(),
+      onValidationWarning: (name, warning) => warnings.push(`${name}:${warning.path}`),
+    });
+    registry.register({
+      name: "wf-with-orphan",
+      initialState: "a",
+      states: { a: {}, orphan: {} },
+    });
+    expect(warnings).toEqual(["wf-with-orphan:states.orphan"]);
+  });
+});

--- a/packages/duraflows-core/tests/unit/workflow-validator.test.ts
+++ b/packages/duraflows-core/tests/unit/workflow-validator.test.ts
@@ -584,4 +584,40 @@ describe("WorkflowValidator", () => {
     expect(result.valid).toBe(true);
     expect(result.errors).toEqual([]);
   });
+
+  // --- unreachable state detection ---
+
+  describe("unreachable state detection", () => {
+    it("warns about states unreachable from the initial state", () => {
+      const result = new WorkflowValidator().validate({
+        name: "wf",
+        initialState: "a",
+        states: {
+          a: { events: { go: { targetState: "b" } } },
+          b: {},
+          orphan: {},
+        },
+      });
+      expect(result.valid).toBe(true); // warnings do not fail validation
+      expect(result.warnings).toEqual([
+        {
+          path: "states.orphan",
+          message: 'State "orphan" is unreachable from initial state "a"',
+        },
+      ]);
+    });
+
+    it("treats onEnter targets and errorStates as reachable", () => {
+      const result = new WorkflowValidator().validate({
+        name: "wf",
+        initialState: "a",
+        states: {
+          a: { onEnter: { commands: [{ name: "x" }], targetState: "b", errorState: "c" } },
+          b: {},
+          c: {},
+        },
+      });
+      expect(result.warnings).toEqual([]);
+    });
+  });
 });

--- a/packages/duraflows-kysely/README.md
+++ b/packages/duraflows-kysely/README.md
@@ -18,6 +18,8 @@ Part of the [duraflows](https://github.com/camcima/duraflows) monorepo.
 pnpm add @duraflows/core @duraflows/kysely kysely pg
 ```
 
+> **Note:** this package no longer declares a `pg` peer dependency. Kysely's `PostgresDialect` requires a driver — install `pg` (or your preferred Postgres driver) alongside this package and configure it on your `Kysely` instance.
+
 ## Quick Start
 
 ```ts

--- a/packages/duraflows-kysely/README.md
+++ b/packages/duraflows-kysely/README.md
@@ -18,7 +18,7 @@ Part of the [duraflows](https://github.com/camcima/duraflows) monorepo.
 pnpm add @duraflows/core @duraflows/kysely kysely pg
 ```
 
-> **Note:** this package no longer declares a `pg` peer dependency. Kysely's `PostgresDialect` requires a driver — install `pg` (or your preferred Postgres driver) alongside this package and configure it on your `Kysely` instance.
+> **Note:** `@duraflows/core` and `kysely` are peer dependencies — you install them alongside this package so your app and the adapter share a single copy. There is intentionally no `pg` peer: Kysely's `PostgresDialect` requires a driver, but the choice is yours — install `pg` (or your preferred Postgres driver) and configure it on your `Kysely` instance.
 
 ## Quick Start
 

--- a/packages/duraflows-kysely/package.json
+++ b/packages/duraflows-kysely/package.json
@@ -51,15 +51,15 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@duraflows/core": "^2.1.0",
     "kysely": "^0.29.2"
+  },
+  "peerDependencies": {
+    "@duraflows/core": "^2.1.0"
   },
   "devDependencies": {
     "pg": "^8.21.0",
     "@types/pg": "^8.11.0",
-    "@duraflows/pg": "workspace:*"
-  },
-  "peerDependencies": {
-    "pg": "^8.13.0"
+    "@duraflows/pg": "workspace:*",
+    "@duraflows/core": "workspace:*"
   }
 }

--- a/packages/duraflows-kysely/package.json
+++ b/packages/duraflows-kysely/package.json
@@ -53,13 +53,12 @@
   "scripts": {
     "build": "tsc --build"
   },
-  "dependencies": {
+  "peerDependencies": {
+    "@duraflows/core": "^2.1.0",
     "kysely": "^0.29.2"
   },
-  "peerDependencies": {
-    "@duraflows/core": "^2.1.0"
-  },
   "devDependencies": {
+    "kysely": "^0.29.2",
     "pg": "^8.21.0",
     "@types/pg": "^8.11.0",
     "@duraflows/pg": "workspace:*",

--- a/packages/duraflows-kysely/package.json
+++ b/packages/duraflows-kysely/package.json
@@ -54,6 +54,11 @@
     "@duraflows/core": "^2.1.0",
     "kysely": "^0.29.2"
   },
+  "devDependencies": {
+    "pg": "^8.21.0",
+    "@types/pg": "^8.11.0",
+    "@duraflows/pg": "workspace:*"
+  },
   "peerDependencies": {
     "pg": "^8.13.0"
   }

--- a/packages/duraflows-kysely/package.json
+++ b/packages/duraflows-kysely/package.json
@@ -41,8 +41,11 @@
       }
     }
   },
+  "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!dist/**/*.tsbuildinfo",
+    "!dist/**/*.map"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/duraflows-kysely/src/kysely-history-store.ts
+++ b/packages/duraflows-kysely/src/kysely-history-store.ts
@@ -44,6 +44,7 @@ export class KyselyWorkflowHistoryStore implements WorkflowHistoryStore {
       .selectAll()
       .where("workflow_instance_uuid", "=", workflowInstanceUuid)
       .orderBy("created_at", "desc")
+      .orderBy("uuid", "desc")
       .limit(limit)
       .offset(offset)
       .execute();

--- a/packages/duraflows-kysely/tests/integration/kysely-adapter.integration.test.ts
+++ b/packages/duraflows-kysely/tests/integration/kysely-adapter.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { randomUUID } from "node:crypto";
 import { Kysely, PostgresDialect, sql } from "kysely";
 import { Pool } from "pg";
@@ -85,6 +85,12 @@ if (!databaseUrl) {
   });
 
   describe("kysely adapter integration", () => {
+    // Cleanup runs in afterEach (not at the end of each test body) so a
+    // failing assertion cannot leak rows into the next test.
+    afterEach(async () => {
+      await sql`TRUNCATE workflow_history, workflow_instances CASCADE`.execute(db);
+    });
+
     it("findExpired executes and claims only expired rows", async () => {
       const expired = makeInstance({ expiresAt: new Date("2020-01-01T00:00:00Z") });
       const future = makeInstance({ expiresAt: new Date("2099-01-01T00:00:00Z") });
@@ -96,7 +102,6 @@ if (!databaseUrl) {
       const found = await transactionRunner.runInTransaction(() => instanceStore.findExpired(10, new Date()));
 
       expect(found.map((i) => i.uuid)).toEqual([expired.uuid]);
-      await sql`TRUNCATE workflow_history, workflow_instances CASCADE`.execute(db);
     });
 
     it("history maps NULL rejected_by/error_message to undefined", async () => {
@@ -115,7 +120,6 @@ if (!databaseUrl) {
       const [record] = await historyStore.findByInstanceUuid(instance.uuid);
       expect(record.rejectedBy).toBeUndefined();
       expect(record.errorMessage).toBeUndefined();
-      await sql`TRUNCATE workflow_history, workflow_instances CASCADE`.execute(db);
     });
   });
 }

--- a/packages/duraflows-kysely/tests/integration/kysely-adapter.integration.test.ts
+++ b/packages/duraflows-kysely/tests/integration/kysely-adapter.integration.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { Kysely, PostgresDialect, sql } from "kysely";
+import { Pool } from "pg";
+import { runInstanceStoreConformance } from "@duraflows/core/testing";
+import type { WorkflowInstance } from "@duraflows/core";
+import { generateMigrationSql } from "@duraflows/pg";
+import {
+  KyselyWorkflowInstanceStore,
+  KyselyWorkflowHistoryStore,
+  KyselyTransactionRunner,
+  type WorkflowDatabase,
+} from "@duraflows/kysely";
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  describe.skip("kysely adapter integration (set DATABASE_URL to run)", () => {
+    it.skip("skipped", () => {});
+  });
+} else {
+  // `options` sets the backend `search_path` as a startup parameter, applied at
+  // connection establishment for EVERY pooled connection before any query runs.
+  // This isolates this suite's tables in a dedicated schema without relying on a
+  // fire-and-forget `pool.on("connect")` handler (which is not awaited and races
+  // with the first query on a freshly opened connection). The path is kysely_it
+  // ONLY (no `public`) so unqualified DDL here can't fall through and drop the
+  // pg suite's public-schema tables when both suites run in parallel; built-ins
+  // like gen_random_uuid() resolve from pg_catalog regardless.
+  const pool = new Pool({ connectionString: databaseUrl, options: "-c search_path=kysely_it" });
+  const db = new Kysely<WorkflowDatabase>({ dialect: new PostgresDialect({ pool }) });
+  const transactionRunner = new KyselyTransactionRunner(db);
+  const instanceStore = new KyselyWorkflowInstanceStore(db);
+  const historyStore = new KyselyWorkflowHistoryStore(db);
+
+  const makeInstance = (overrides?: Partial<WorkflowInstance>): WorkflowInstance => ({
+    uuid: randomUUID(),
+    workflowName: "integration-test",
+    currentState: "initial",
+    version: 0,
+    expiresAt: null,
+    lastTransitionAt: new Date("2026-01-01T00:00:00Z"),
+    context: {},
+    metadata: {},
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  });
+
+  beforeAll(async () => {
+    // Bootstrap the dedicated schema on a single pg client. `generateMigrationSql`
+    // returns a multi-statement string, which Kysely's `sql.execute()` cannot run
+    // (the wire protocol returns one result set), so a raw client is used here.
+    // The pool's `search_path` startup option (kysely_it) already points every
+    // connection at this schema; CREATE SCHEMA below is unqualified-DDL-safe.
+    const client = await pool.connect();
+    try {
+      await client.query("CREATE SCHEMA IF NOT EXISTS kysely_it");
+      await client.query("DROP TABLE IF EXISTS workflow_history, workflow_instances CASCADE");
+      const { up } = generateMigrationSql();
+      await client.query(up);
+    } finally {
+      client.release();
+    }
+  });
+
+  afterAll(async () => {
+    const client = await pool.connect();
+    try {
+      await client.query("DROP SCHEMA IF EXISTS kysely_it CASCADE");
+    } finally {
+      client.release();
+    }
+    await db.destroy();
+  });
+
+  runInstanceStoreConformance("kysely (real PostgreSQL)", {
+    setup: async () => ({
+      store: instanceStore,
+      transactionRunner,
+      teardown: async () => {
+        await sql`TRUNCATE workflow_history, workflow_instances CASCADE`.execute(db);
+      },
+    }),
+  });
+
+  describe("kysely adapter integration", () => {
+    it("findExpired executes and claims only expired rows", async () => {
+      const expired = makeInstance({ expiresAt: new Date("2020-01-01T00:00:00Z") });
+      const future = makeInstance({ expiresAt: new Date("2099-01-01T00:00:00Z") });
+      await transactionRunner.runInTransaction(async () => {
+        await instanceStore.create(expired);
+        await instanceStore.create(future);
+      });
+
+      const found = await transactionRunner.runInTransaction(() => instanceStore.findExpired(10, new Date()));
+
+      expect(found.map((i) => i.uuid)).toEqual([expired.uuid]);
+      await sql`TRUNCATE workflow_history, workflow_instances CASCADE`.execute(db);
+    });
+
+    it("history maps NULL rejected_by/error_message to undefined", async () => {
+      const instance = makeInstance();
+      await transactionRunner.runInTransaction(() => instanceStore.create(instance));
+      await transactionRunner.runInTransaction(() =>
+        historyStore.append({
+          workflowInstanceUuid: instance.uuid,
+          fromState: null,
+          eventName: "__create__",
+          toState: "initial",
+          outcome: "success",
+          commandResultsJson: [],
+        }),
+      );
+      const [record] = await historyStore.findByInstanceUuid(instance.uuid);
+      expect(record.rejectedBy).toBeUndefined();
+      expect(record.errorMessage).toBeUndefined();
+      await sql`TRUNCATE workflow_history, workflow_instances CASCADE`.execute(db);
+    });
+  });
+}

--- a/packages/duraflows-kysely/tests/unit/kysely-instance-store.test.ts
+++ b/packages/duraflows-kysely/tests/unit/kysely-instance-store.test.ts
@@ -182,6 +182,17 @@ describe("KyselyWorkflowInstanceStore", () => {
       await expect(store.update(updated)).rejects.toThrow("Optimistic locking failure");
     });
 
+    it("throws WorkflowError when the update returns an empty result array", async () => {
+      // Some dialects/drivers can resolve to [] instead of a row with
+      // numUpdatedRows — the `?? BigInt(0)` fallback must treat it as a miss.
+      const { db, executeMock } = createMockDb();
+      executeMock.mockResolvedValue([]);
+      const store = new KyselyWorkflowInstanceStore(db);
+
+      const updated = { ...sampleInstance, version: 1 };
+      await expect(store.update(updated)).rejects.toThrow(/Optimistic locking failure/);
+    });
+
     it("does not include metadata_json in the SET payload (metadata is immutable)", async () => {
       const { db, executeMock, calls } = createMockDb();
       executeMock.mockResolvedValue([{ numUpdatedRows: BigInt(1) }]);

--- a/packages/duraflows-nestjs/README.md
+++ b/packages/duraflows-nestjs/README.md
@@ -157,6 +157,8 @@ export class SendToWarehouseCommand implements IWorkflowCommand {
 
 When `enableControllers: true` is set, the following endpoints are registered:
 
+> **Security:** the generated controllers ship **without authentication**. They expose instance creation, arbitrary event triggering, full history reads, and `POST /workflows/timeouts/process` (an administrative bulk operation). Apply your own auth guards and rate limiting before enabling them in production — e.g. a global `APP_GUARD`, or guards bound per controller. Note also that `triggerEvent` responses include each command's `CommandResult` verbatim, so command authors must not place sensitive data in `CommandResult.error` / `message` if the controllers are enabled.
+
 | Controller                   | Endpoints                              |
 | ---------------------------- | -------------------------------------- |
 | `WorkflowInstanceController` | Create and retrieve workflow instances |

--- a/packages/duraflows-nestjs/package.json
+++ b/packages/duraflows-nestjs/package.json
@@ -50,17 +50,20 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@duraflows/core": "^2.1.0",
-    "@nestjs/common": "^11.1.24",
-    "@nestjs/core": "^11.1.24",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1"
   },
   "peerDependencies": {
+    "@duraflows/core": "^2.1.0",
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.0.0"
   },
   "devDependencies": {
+    "@duraflows/core": "workspace:*",
+    "@nestjs/common": "^11.1.24",
+    "@nestjs/core": "^11.1.24",
     "@nestjs/testing": "^11.1.24"
   }
 }

--- a/packages/duraflows-nestjs/package.json
+++ b/packages/duraflows-nestjs/package.json
@@ -40,8 +40,11 @@
       }
     }
   },
+  "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "!dist/**/*.tsbuildinfo",
+    "!dist/**/*.map"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/duraflows-nestjs/src/controllers/dto/history-query.dto.ts
+++ b/packages/duraflows-nestjs/src/controllers/dto/history-query.dto.ts
@@ -1,13 +1,19 @@
-import { IsOptional, IsNumberString, IsUUID } from "class-validator";
+import { Type } from "class-transformer";
+import { IsInt, IsOptional, IsUUID, Max, Min } from "class-validator";
 
 export class HistoryQueryDto {
   @IsOptional()
-  @IsNumberString()
-  limit?: string;
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  limit?: number;
 
   @IsOptional()
-  @IsNumberString()
-  offset?: string;
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number;
 }
 
 export class HistoryParamsDto {

--- a/packages/duraflows-nestjs/src/controllers/dto/timeout-process.dto.ts
+++ b/packages/duraflows-nestjs/src/controllers/dto/timeout-process.dto.ts
@@ -1,7 +1,11 @@
-import { IsOptional, IsNumberString } from "class-validator";
+import { Type } from "class-transformer";
+import { IsInt, IsOptional, Max, Min } from "class-validator";
 
 export class TimeoutProcessQueryDto {
   @IsOptional()
-  @IsNumberString()
-  limit?: string;
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  limit?: number;
 }

--- a/packages/duraflows-nestjs/src/controllers/workflow-event.controller.ts
+++ b/packages/duraflows-nestjs/src/controllers/workflow-event.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Post, Param, Body, UsePipes, ValidationPipe } from "@nestjs/common";
+import { Controller, Post, Param, Body, UsePipes, UseFilters, ValidationPipe } from "@nestjs/common";
 import type { WorkflowExecutionResult } from "@duraflows/core";
 import { WorkflowService } from "../services/workflow.service.js";
 import { TriggerEventDto, TriggerEventParamsDto } from "./dto/index.js";
+import { WorkflowExceptionFilter } from "../filters/workflow-exception.filter.js";
 
 @Controller("workflows")
+@UseFilters(WorkflowExceptionFilter)
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class WorkflowEventController {
   constructor(private readonly workflowService: WorkflowService) {}

--- a/packages/duraflows-nestjs/src/controllers/workflow-event.controller.ts
+++ b/packages/duraflows-nestjs/src/controllers/workflow-event.controller.ts
@@ -6,7 +6,7 @@ import { WorkflowExceptionFilter } from "../filters/workflow-exception.filter.js
 
 @Controller("workflows")
 @UseFilters(WorkflowExceptionFilter)
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }))
 export class WorkflowEventController {
   constructor(private readonly workflowService: WorkflowService) {}
 

--- a/packages/duraflows-nestjs/src/controllers/workflow-instance.controller.ts
+++ b/packages/duraflows-nestjs/src/controllers/workflow-instance.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   Body,
   UsePipes,
+  UseFilters,
   ValidationPipe,
   NotFoundException,
   ParseUUIDPipe,
@@ -12,8 +13,10 @@ import {
 import type { WorkflowInstance } from "@duraflows/core";
 import { WorkflowService } from "../services/workflow.service.js";
 import { CreateInstanceDto } from "./dto/index.js";
+import { WorkflowExceptionFilter } from "../filters/workflow-exception.filter.js";
 
 @Controller("workflows")
+@UseFilters(WorkflowExceptionFilter)
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class WorkflowInstanceController {
   constructor(private readonly workflowService: WorkflowService) {}

--- a/packages/duraflows-nestjs/src/controllers/workflow-instance.controller.ts
+++ b/packages/duraflows-nestjs/src/controllers/workflow-instance.controller.ts
@@ -17,7 +17,7 @@ import { WorkflowExceptionFilter } from "../filters/workflow-exception.filter.js
 
 @Controller("workflows")
 @UseFilters(WorkflowExceptionFilter)
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }))
 export class WorkflowInstanceController {
   constructor(private readonly workflowService: WorkflowService) {}
 

--- a/packages/duraflows-nestjs/src/controllers/workflow-query.controller.ts
+++ b/packages/duraflows-nestjs/src/controllers/workflow-query.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Get, Param, Query, UsePipes, ValidationPipe } from "@nestjs/common";
+import { Controller, Get, Param, Query, UsePipes, UseFilters, ValidationPipe } from "@nestjs/common";
 import type { AvailableWorkflowEvent, WorkflowHistoryRecord } from "@duraflows/core";
 import { WorkflowService } from "../services/workflow.service.js";
 import { AvailableEventsParamsDto, HistoryQueryDto, HistoryParamsDto } from "./dto/index.js";
+import { WorkflowExceptionFilter } from "../filters/workflow-exception.filter.js";
 
 @Controller("workflows")
+@UseFilters(WorkflowExceptionFilter)
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class WorkflowQueryController {
   constructor(private readonly workflowService: WorkflowService) {}

--- a/packages/duraflows-nestjs/src/controllers/workflow-query.controller.ts
+++ b/packages/duraflows-nestjs/src/controllers/workflow-query.controller.ts
@@ -6,7 +6,7 @@ import { WorkflowExceptionFilter } from "../filters/workflow-exception.filter.js
 
 @Controller("workflows")
 @UseFilters(WorkflowExceptionFilter)
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }))
 export class WorkflowQueryController {
   constructor(private readonly workflowService: WorkflowService) {}
 
@@ -23,8 +23,8 @@ export class WorkflowQueryController {
     @Query() query: HistoryQueryDto,
   ): Promise<WorkflowHistoryRecord[]> {
     return this.workflowService.getHistory(params.workflowInstanceUuid, {
-      limit: query.limit ? parseInt(query.limit, 10) : undefined,
-      offset: query.offset ? parseInt(query.offset, 10) : undefined,
+      limit: query.limit,
+      offset: query.offset,
     });
   }
 }

--- a/packages/duraflows-nestjs/src/controllers/workflow-timeout.controller.ts
+++ b/packages/duraflows-nestjs/src/controllers/workflow-timeout.controller.ts
@@ -6,12 +6,12 @@ import { WorkflowExceptionFilter } from "../filters/workflow-exception.filter.js
 
 @Controller("workflows/timeouts")
 @UseFilters(WorkflowExceptionFilter)
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }))
 export class WorkflowTimeoutController {
   constructor(private readonly timeoutService: WorkflowTimeoutService) {}
 
   @Post("process")
   async processExpired(@Query() query: TimeoutProcessQueryDto): Promise<ProcessExpiredWorkflowsResult> {
-    return this.timeoutService.processExpiredWorkflows(query.limit ? parseInt(query.limit, 10) : undefined);
+    return this.timeoutService.processExpiredWorkflows(query.limit);
   }
 }

--- a/packages/duraflows-nestjs/src/controllers/workflow-timeout.controller.ts
+++ b/packages/duraflows-nestjs/src/controllers/workflow-timeout.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Post, Query, UsePipes, ValidationPipe } from "@nestjs/common";
+import { Controller, Post, Query, UsePipes, UseFilters, ValidationPipe } from "@nestjs/common";
 import type { ProcessExpiredWorkflowsResult } from "@duraflows/core";
 import { WorkflowTimeoutService } from "../services/workflow-timeout.service.js";
 import { TimeoutProcessQueryDto } from "./dto/index.js";
+import { WorkflowExceptionFilter } from "../filters/workflow-exception.filter.js";
 
 @Controller("workflows/timeouts")
+@UseFilters(WorkflowExceptionFilter)
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class WorkflowTimeoutController {
   constructor(private readonly timeoutService: WorkflowTimeoutService) {}

--- a/packages/duraflows-nestjs/src/filters/workflow-exception.filter.ts
+++ b/packages/duraflows-nestjs/src/filters/workflow-exception.filter.ts
@@ -1,0 +1,43 @@
+import { Catch, HttpStatus, type ArgumentsHost, type ExceptionFilter } from "@nestjs/common";
+import { WorkflowError, WorkflowInstanceNotFoundError, InvalidEventError } from "@duraflows/core";
+
+interface HttpResponseLike {
+  status(code: number): { json(body: unknown): void };
+}
+
+/**
+ * Maps duraflows domain errors to HTTP statuses for the optional REST
+ * controllers. Without this filter, a missing instance or an event invalid
+ * for the current state surfaces as a generic 500 and leaks internal
+ * messages.
+ */
+@Catch(WorkflowError)
+export class WorkflowExceptionFilter implements ExceptionFilter {
+  catch(exception: WorkflowError, host: ArgumentsHost): void {
+    const response = host.switchToHttp().getResponse<HttpResponseLike>();
+
+    if (exception instanceof WorkflowInstanceNotFoundError) {
+      response.status(HttpStatus.NOT_FOUND).json({
+        statusCode: HttpStatus.NOT_FOUND,
+        error: "Not Found",
+        message: exception.message,
+      });
+      return;
+    }
+
+    if (exception instanceof InvalidEventError) {
+      response.status(HttpStatus.CONFLICT).json({
+        statusCode: HttpStatus.CONFLICT,
+        error: "Conflict",
+        message: exception.message,
+      });
+      return;
+    }
+
+    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      error: "Internal Server Error",
+      message: "Internal server error",
+    });
+  }
+}

--- a/packages/duraflows-nestjs/src/filters/workflow-exception.filter.ts
+++ b/packages/duraflows-nestjs/src/filters/workflow-exception.filter.ts
@@ -1,8 +1,10 @@
-import { Catch, HttpStatus, type ArgumentsHost, type ExceptionFilter } from "@nestjs/common";
+import { Catch, HttpStatus, Logger, type ArgumentsHost, type ExceptionFilter } from "@nestjs/common";
 import { WorkflowError, WorkflowInstanceNotFoundError, InvalidEventError } from "@duraflows/core";
 
+// `send()` (unlike `json()`) exists on both Express and Fastify replies, and
+// both serialize a plain object to JSON — keep this filter platform-agnostic.
 interface HttpResponseLike {
-  status(code: number): { json(body: unknown): void };
+  status(code: number): { send(body: unknown): void };
 }
 
 /**
@@ -13,11 +15,13 @@ interface HttpResponseLike {
  */
 @Catch(WorkflowError)
 export class WorkflowExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(WorkflowExceptionFilter.name);
+
   catch(exception: WorkflowError, host: ArgumentsHost): void {
     const response = host.switchToHttp().getResponse<HttpResponseLike>();
 
     if (exception instanceof WorkflowInstanceNotFoundError) {
-      response.status(HttpStatus.NOT_FOUND).json({
+      response.status(HttpStatus.NOT_FOUND).send({
         statusCode: HttpStatus.NOT_FOUND,
         error: "Not Found",
         message: exception.message,
@@ -26,7 +30,7 @@ export class WorkflowExceptionFilter implements ExceptionFilter {
     }
 
     if (exception instanceof InvalidEventError) {
-      response.status(HttpStatus.CONFLICT).json({
+      response.status(HttpStatus.CONFLICT).send({
         statusCode: HttpStatus.CONFLICT,
         error: "Conflict",
         message: exception.message,
@@ -34,7 +38,11 @@ export class WorkflowExceptionFilter implements ExceptionFilter {
       return;
     }
 
-    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+    // The response body is sanitized, so log the real cause here — otherwise
+    // unmapped domain errors (e.g. optimistic-locking conflicts under
+    // concurrency) become undiagnosable silent 500s.
+    this.logger.error(exception.message, exception.stack);
+    response.status(HttpStatus.INTERNAL_SERVER_ERROR).send({
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
       error: "Internal Server Error",
       message: "Internal server error",

--- a/packages/duraflows-nestjs/src/filters/workflow-exception.filter.ts
+++ b/packages/duraflows-nestjs/src/filters/workflow-exception.filter.ts
@@ -40,8 +40,15 @@ export class WorkflowExceptionFilter implements ExceptionFilter {
 
     // The response body is sanitized, so log the real cause here — otherwise
     // unmapped domain errors (e.g. optimistic-locking conflicts under
-    // concurrency) become undiagnosable silent 500s.
-    this.logger.error(exception.message, exception.stack);
+    // concurrency) become undiagnosable silent 500s. `WorkflowError` wraps the
+    // originating DI/persistence failure as `cause` (e.g. NestCommandRegistry
+    // attaches the container error), so prefer the cause's message and stack —
+    // the wrapper alone hides the underlying failure from operators.
+    const cause = exception.cause instanceof Error ? exception.cause : undefined;
+    this.logger.error(
+      cause ? `${exception.message} (cause: ${cause.message})` : exception.message,
+      (cause ?? exception).stack,
+    );
     response.status(HttpStatus.INTERNAL_SERVER_ERROR).send({
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
       error: "Internal Server Error",

--- a/packages/duraflows-nestjs/src/index.ts
+++ b/packages/duraflows-nestjs/src/index.ts
@@ -80,6 +80,7 @@ export type {
 export {
   WorkflowError,
   WorkflowDefinitionError,
+  WorkflowInstanceNotFoundError,
   InvalidEventError,
   CommandFailureError,
   OnEnterDepthExceededError,

--- a/packages/duraflows-nestjs/src/index.ts
+++ b/packages/duraflows-nestjs/src/index.ts
@@ -33,6 +33,9 @@ export { WorkflowEventController } from "./controllers/workflow-event.controller
 export { WorkflowQueryController } from "./controllers/workflow-query.controller.js";
 export { WorkflowTimeoutController } from "./controllers/workflow-timeout.controller.js";
 
+// Filters
+export { WorkflowExceptionFilter } from "./filters/workflow-exception.filter.js";
+
 // DTOs
 export {
   TriggerEventDto,

--- a/packages/duraflows-nestjs/src/providers/nest-command-registry.ts
+++ b/packages/duraflows-nestjs/src/providers/nest-command-registry.ts
@@ -31,12 +31,19 @@ export class NestCommandRegistry implements WorkflowCommandRegistry {
     try {
       return this.moduleRef.get(cls, { strict: false });
     } catch (error) {
-      throw new WorkflowError(
-        `Command "${name}" could not be resolved from the NestJS container. ` +
-          `Workflow command providers must be singleton-scoped (the default); ` +
-          `REQUEST- and TRANSIENT-scoped providers are not supported.`,
-        error,
-      );
+      // `ModuleRef.get()` fails for many reasons — a missing provider, a
+      // circular dependency, a throwing constructor — not only unsupported
+      // scopes. Wrap every failure with a generic resolution message and only
+      // add the singleton-scope hint when the underlying error is Nest's
+      // scoped-provider rejection, so the guidance is never misleading. The
+      // original error is attached as the cause either way.
+      let message = `Command "${name}" could not be resolved from the NestJS container.`;
+      if (isScopedProviderError(error)) {
+        message +=
+          ` Workflow command providers must be singleton-scoped (the default); ` +
+          `REQUEST- and TRANSIENT-scoped providers are not supported.`;
+      }
+      throw new WorkflowError(message, error);
     }
   }
 
@@ -47,4 +54,17 @@ export class NestCommandRegistry implements WorkflowCommandRegistry {
   getRegisteredNames(): Set<string> {
     return new Set(this.registrations.keys());
   }
+}
+
+/**
+ * Nest throws `InvalidClassScopeException` (message: "... is marked as a scoped
+ * provider ...") when `get()` is called on a REQUEST/TRANSIENT provider. That
+ * class is not part of Nest's public API, so match on the constructor name with
+ * a message-content fallback to survive version drift.
+ */
+function isScopedProviderError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.constructor.name === "InvalidClassScopeException" || /scoped provider/i.test(error.message);
 }

--- a/packages/duraflows-nestjs/src/providers/nest-command-registry.ts
+++ b/packages/duraflows-nestjs/src/providers/nest-command-registry.ts
@@ -28,7 +28,16 @@ export class NestCommandRegistry implements WorkflowCommandRegistry {
     if (!cls) {
       throw new WorkflowError(`Command "${name}" not found in registry`);
     }
-    return this.moduleRef.get(cls, { strict: false });
+    try {
+      return this.moduleRef.get(cls, { strict: false });
+    } catch (error) {
+      throw new WorkflowError(
+        `Command "${name}" could not be resolved from the NestJS container. ` +
+          `Workflow command providers must be singleton-scoped (the default); ` +
+          `REQUEST- and TRANSIENT-scoped providers are not supported.`,
+        error,
+      );
+    }
   }
 
   has(name: string): boolean {

--- a/packages/duraflows-nestjs/src/workflow.module.ts
+++ b/packages/duraflows-nestjs/src/workflow.module.ts
@@ -66,7 +66,12 @@ export interface WorkflowModuleAsyncOptions<TArgs extends unknown[] = unknown[]>
   commands?: WorkflowCommandRegistration[];
   enableControllers?: boolean;
   useFactory: (...args: TArgs) => Promise<WorkflowModuleFactoryConfig> | WorkflowModuleFactoryConfig;
-  inject?: InjectionToken[];
+  /**
+   * DI tokens resolved and passed to `useFactory`, positionally. The tuple
+   * length is type-checked against the factory's parameter list when `TArgs`
+   * is supplied (e.g. `forRootAsync<[Pool, AuditObserver]>({ ... })`).
+   */
+  inject?: { [K in keyof TArgs]: InjectionToken };
 }
 
 const EXPORTED_TOKENS = [
@@ -220,7 +225,7 @@ export class WorkflowModule {
     const configProvider: Provider = {
       provide: "WORKFLOW_MODULE_OPTIONS",
       useFactory: options.useFactory,
-      inject: options.inject ?? [],
+      inject: (options.inject ?? []) as InjectionToken[],
     };
 
     const providers: Provider[] = [

--- a/packages/duraflows-nestjs/src/workflow.module.ts
+++ b/packages/duraflows-nestjs/src/workflow.module.ts
@@ -117,12 +117,9 @@ export class WorkflowModule {
       },
       {
         provide: WORKFLOW_GUARD_REGISTRY,
+        // guards/guardRegistry mutual exclusion is enforced synchronously at
+        // the top of forRoot, before this factory can ever run.
         useFactory: () => {
-          if (options.guardRegistry && options.guards && options.guards.length > 0) {
-            throw new Error(
-              "WorkflowModule: cannot supply both `guards` and `guardRegistry` — they are mutually exclusive. Pass guards or a custom registry, not both.",
-            );
-          }
           if (options.guardRegistry) return options.guardRegistry;
           const registry = new InMemoryGuardRegistry();
           for (const guard of options.guards ?? []) {

--- a/packages/duraflows-nestjs/src/workflow.module.ts
+++ b/packages/duraflows-nestjs/src/workflow.module.ts
@@ -1,4 +1,4 @@
-import { Module, type DynamicModule, type Type, type Provider, type InjectionToken } from "@nestjs/common";
+import { Logger, Module, type DynamicModule, type Type, type Provider, type InjectionToken } from "@nestjs/common";
 import { DiscoveryModule, DiscoveryService, ModuleRef } from "@nestjs/core";
 import type {
   WorkflowDefinition,
@@ -74,6 +74,13 @@ export interface WorkflowModuleAsyncOptions<TArgs extends unknown[] = unknown[]>
   inject?: { [K in keyof TArgs]: InjectionToken };
 }
 
+// Surfaces non-fatal definition warnings (e.g. unreachable states) that the
+// registry would otherwise compute and discard.
+const validationLogger = new Logger("WorkflowModule");
+const logValidationWarning = (workflowName: string, warning: { path: string; message: string }): void => {
+  validationLogger.warn(`Workflow "${workflowName}": ${warning.message} (${warning.path})`);
+};
+
 const EXPORTED_TOKENS = [
   WorkflowService,
   WorkflowTimeoutService,
@@ -141,6 +148,7 @@ export class WorkflowModule {
             validator: new WorkflowValidator(),
             compiler: new WorkflowCompiler(),
             validationOptions: { knownCommandNames, knownGuardNames },
+            onValidationWarning: logValidationWarning,
           });
           for (const workflow of options.workflows) {
             registry.register(workflow);
@@ -267,6 +275,7 @@ export class WorkflowModule {
             validator: new WorkflowValidator(),
             compiler: new WorkflowCompiler(),
             validationOptions: { knownCommandNames, knownGuardNames },
+            onValidationWarning: logValidationWarning,
           });
           for (const workflow of config.workflows) {
             registry.register(workflow);

--- a/packages/duraflows-nestjs/src/workflow.module.ts
+++ b/packages/duraflows-nestjs/src/workflow.module.ts
@@ -1,4 +1,12 @@
-import { Logger, Module, type DynamicModule, type Type, type Provider, type InjectionToken } from "@nestjs/common";
+import {
+  Logger,
+  Module,
+  type DynamicModule,
+  type Type,
+  type Provider,
+  type InjectionToken,
+  type OptionalFactoryDependency,
+} from "@nestjs/common";
 import { DiscoveryModule, DiscoveryService, ModuleRef } from "@nestjs/core";
 import type {
   WorkflowDefinition,
@@ -71,7 +79,7 @@ export interface WorkflowModuleAsyncOptions<TArgs extends unknown[] = unknown[]>
    * length is type-checked against the factory's parameter list when `TArgs`
    * is supplied (e.g. `forRootAsync<[Pool, AuditObserver]>({ ... })`).
    */
-  inject?: { [K in keyof TArgs]: InjectionToken };
+  inject?: { [K in keyof TArgs]: InjectionToken | OptionalFactoryDependency };
 }
 
 // Surfaces non-fatal definition warnings (e.g. unreachable states) that the
@@ -230,7 +238,7 @@ export class WorkflowModule {
     const configProvider: Provider = {
       provide: "WORKFLOW_MODULE_OPTIONS",
       useFactory: options.useFactory,
-      inject: (options.inject ?? []) as InjectionToken[],
+      inject: (options.inject ?? []) as Array<InjectionToken | OptionalFactoryDependency>,
     };
 
     const providers: Provider[] = [

--- a/packages/duraflows-nestjs/tests/integration/workflow-module-forroot.test.ts
+++ b/packages/duraflows-nestjs/tests/integration/workflow-module-forroot.test.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Test, type TestingModule } from "@nestjs/testing";
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import {
   WorkflowModule,
   WorkflowService,
@@ -366,6 +366,62 @@ describe("WorkflowModule.forRoot()", () => {
         guardRegistry: customRegistry,
       }),
     ).toThrow(/cannot supply both `guards` and `guardRegistry`/);
+  });
+
+  it("logs a warning for workflows with unreachable states at registration", async () => {
+    const warnSpy = vi.spyOn(Logger.prototype, "warn").mockImplementation(() => undefined);
+
+    const definitionWithOrphan: WorkflowDefinition = {
+      name: "orphan-wf",
+      initialState: "a",
+      states: {
+        a: {},
+        orphan: {}, // no inbound transitions — unreachable from "a"
+      },
+    };
+
+    try {
+      const mod = await Test.createTestingModule({
+        imports: [
+          WorkflowModule.forRoot(
+            defaultOptions({
+              workflows: [definitionWithOrphan],
+              commands: [],
+            }),
+          ),
+        ],
+      }).compile();
+
+      // Resolving the registry guarantees the provider factory (and thus
+      // registration + warning emission) has run.
+      const registry = mod.get<WorkflowDefinitionRegistry>(WORKFLOW_DEFINITION_REGISTRY);
+      expect(registry.has("orphan-wf")).toBe(true);
+
+      const warnMessages = warnSpy.mock.calls.map((call) => String(call[0]));
+      expect(warnMessages.some((m) => m.includes("unreachable") && m.includes("orphan"))).toBe(true);
+
+      await mod.close();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("defaults the clock to the system clock when no clock option is provided", async () => {
+    const before = new Date();
+
+    const mod = await Test.createTestingModule({
+      imports: [WorkflowModule.forRoot(defaultOptions({ clock: undefined }))],
+    }).compile();
+
+    const service = mod.get(WorkflowService);
+    const instance = await service.createInstance({ workflowName: "test-order" });
+
+    const after = new Date();
+    expect(instance.createdAt).toBeInstanceOf(Date);
+    expect(instance.createdAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(instance.createdAt.getTime()).toBeLessThanOrEqual(after.getTime());
+
+    await mod.close();
   });
 
   it("forwards observers from WorkflowModule.forRoot to WorkflowRuntime", async () => {

--- a/packages/duraflows-nestjs/tests/integration/workflow-module-forrootasync.test.ts
+++ b/packages/duraflows-nestjs/tests/integration/workflow-module-forrootasync.test.ts
@@ -365,6 +365,33 @@ describe("WorkflowModule.forRootAsync()", () => {
     expect(definitionRegistry.has("guarded-async-wf")).toBe(true);
   });
 
+  it("defaults the clock to the system clock when the async factory config omits clock", async () => {
+    const before = new Date();
+
+    const mod = await Test.createTestingModule({
+      imports: [
+        WorkflowModule.forRootAsync({
+          commands: [{ name: "test-ship", useClass: TestShipCommand }],
+          useFactory: () => ({
+            workflows: [testWorkflow],
+            persistence: stubPersistence,
+            // no clock — the module must fall back to the system clock
+          }),
+        }),
+      ],
+    }).compile();
+
+    const service = mod.get(WorkflowService);
+    const instance = await service.createInstance({ workflowName: "test-shipping" });
+
+    const after = new Date();
+    expect(instance.createdAt).toBeInstanceOf(Date);
+    expect(instance.createdAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(instance.createdAt.getTime()).toBeLessThanOrEqual(after.getTime());
+
+    await mod.close();
+  });
+
   it("forwards observers returned from forRootAsync useFactory config to WorkflowRuntime", async () => {
     const captured: { state: string }[] = [];
 

--- a/packages/duraflows-nestjs/tests/unit/nest-command-registry.test.ts
+++ b/packages/duraflows-nestjs/tests/unit/nest-command-registry.test.ts
@@ -94,4 +94,41 @@ describe("NestCommandRegistry", () => {
     const registry = new NestCommandRegistry(moduleRef, [{ name: "scoped", useClass: ScopedCommand as any }]);
     expect(() => registry.get("scoped")).toThrow(/singleton-scoped/);
   });
+
+  it("detects the scoped-provider error by its Nest exception class name", () => {
+    // Nest's real InvalidClassScopeException leaves `.name` as "Error"; the
+    // distinguishing signal is the constructor name, not the message.
+    class InvalidClassScopeException extends Error {}
+    const moduleRef = {
+      get: vi.fn(() => {
+        throw new InvalidClassScopeException("unhelpful generic text");
+      }),
+    } as unknown as ModuleRef;
+    class ScopedCommand {}
+    const registry = new NestCommandRegistry(moduleRef, [{ name: "scoped", useClass: ScopedCommand as any }]);
+    expect(() => registry.get("scoped")).toThrow(/singleton-scoped/);
+  });
+
+  it("does not blame singleton scope for unrelated resolution failures", () => {
+    const cause = new Error("Nest can't resolve dependencies of the StubCommandA (circular dependency).");
+    const moduleRef = {
+      get: vi.fn(() => {
+        throw cause;
+      }),
+    } as unknown as ModuleRef;
+    const registry = new NestCommandRegistry(moduleRef, [{ name: "cmdA", useClass: StubCommandA }]);
+
+    let thrown: unknown;
+    try {
+      registry.get("cmdA");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(WorkflowError);
+    expect((thrown as Error).message).toMatch(/could not be resolved from the NestJS container/);
+    expect((thrown as Error).message).not.toMatch(/singleton-scoped/);
+    // The original container error is preserved as the cause for diagnosis.
+    expect((thrown as WorkflowError).cause).toBe(cause);
+  });
 });

--- a/packages/duraflows-nestjs/tests/unit/nest-command-registry.test.ts
+++ b/packages/duraflows-nestjs/tests/unit/nest-command-registry.test.ts
@@ -83,4 +83,15 @@ describe("NestCommandRegistry", () => {
     expect(registry.getRegisteredNames()).toEqual(new Set());
     expect(registry.has("anything")).toBe(false);
   });
+
+  it("wraps scope-resolution failures with a singleton-scope hint", () => {
+    const moduleRef = {
+      get: vi.fn(() => {
+        throw new Error("ScopedCommand is marked as a scoped provider. Use the resolve() method instead.");
+      }),
+    } as unknown as ModuleRef;
+    class ScopedCommand {}
+    const registry = new NestCommandRegistry(moduleRef, [{ name: "scoped", useClass: ScopedCommand as any }]);
+    expect(() => registry.get("scoped")).toThrow(/singleton-scoped/);
+  });
 });

--- a/packages/duraflows-nestjs/tests/unit/workflow-exception.filter.test.ts
+++ b/packages/duraflows-nestjs/tests/unit/workflow-exception.filter.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ArgumentsHost } from "@nestjs/common";
+import { WorkflowError, WorkflowInstanceNotFoundError, InvalidEventError } from "@duraflows/core";
+import { WorkflowExceptionFilter } from "../../src/filters/workflow-exception.filter.js";
+
+function mockHost() {
+  const json = vi.fn();
+  const status = vi.fn().mockReturnValue({ json });
+  const host = {
+    switchToHttp: () => ({ getResponse: () => ({ status }) }),
+  } as unknown as ArgumentsHost;
+  return { host, status, json };
+}
+
+describe("WorkflowExceptionFilter", () => {
+  it("maps WorkflowInstanceNotFoundError to 404", () => {
+    const { host, status, json } = mockHost();
+    new WorkflowExceptionFilter().catch(new WorkflowInstanceNotFoundError("abc"), host);
+    expect(status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith({
+      statusCode: 404,
+      error: "Not Found",
+      message: 'Workflow instance "abc" not found',
+    });
+  });
+
+  it("maps InvalidEventError to 409", () => {
+    const { host, status, json } = mockHost();
+    new WorkflowExceptionFilter().catch(new InvalidEventError("abc", "draft", "approve"), host);
+    expect(status).toHaveBeenCalledWith(409);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 409, error: "Conflict" }));
+  });
+
+  it("maps any other WorkflowError to a generic 500 without leaking the message", () => {
+    const { host, status, json } = mockHost();
+    new WorkflowExceptionFilter().catch(new WorkflowError("internal detail: uuid xyz"), host);
+    expect(status).toHaveBeenCalledWith(500);
+    expect(json).toHaveBeenCalledWith({
+      statusCode: 500,
+      error: "Internal Server Error",
+      message: "Internal server error",
+    });
+  });
+});

--- a/packages/duraflows-nestjs/tests/unit/workflow-exception.filter.test.ts
+++ b/packages/duraflows-nestjs/tests/unit/workflow-exception.filter.test.ts
@@ -1,23 +1,25 @@
 import { describe, it, expect, vi } from "vitest";
-import type { ArgumentsHost } from "@nestjs/common";
+import { Logger, type ArgumentsHost } from "@nestjs/common";
 import { WorkflowError, WorkflowInstanceNotFoundError, InvalidEventError } from "@duraflows/core";
 import { WorkflowExceptionFilter } from "../../src/filters/workflow-exception.filter.js";
 
+// The filter must stay platform-agnostic: it may only call `.status(...).send(...)`,
+// which exists on both Express and Fastify replies (`.json()` is Express-only).
 function mockHost() {
-  const json = vi.fn();
-  const status = vi.fn().mockReturnValue({ json });
+  const send = vi.fn();
+  const status = vi.fn().mockReturnValue({ send });
   const host = {
     switchToHttp: () => ({ getResponse: () => ({ status }) }),
   } as unknown as ArgumentsHost;
-  return { host, status, json };
+  return { host, status, send };
 }
 
 describe("WorkflowExceptionFilter", () => {
   it("maps WorkflowInstanceNotFoundError to 404", () => {
-    const { host, status, json } = mockHost();
+    const { host, status, send } = mockHost();
     new WorkflowExceptionFilter().catch(new WorkflowInstanceNotFoundError("abc"), host);
     expect(status).toHaveBeenCalledWith(404);
-    expect(json).toHaveBeenCalledWith({
+    expect(send).toHaveBeenCalledWith({
       statusCode: 404,
       error: "Not Found",
       message: 'Workflow instance "abc" not found',
@@ -25,20 +27,49 @@ describe("WorkflowExceptionFilter", () => {
   });
 
   it("maps InvalidEventError to 409", () => {
-    const { host, status, json } = mockHost();
+    const { host, status, send } = mockHost();
     new WorkflowExceptionFilter().catch(new InvalidEventError("abc", "draft", "approve"), host);
     expect(status).toHaveBeenCalledWith(409);
-    expect(json).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 409, error: "Conflict" }));
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 409, error: "Conflict" }));
   });
 
   it("maps any other WorkflowError to a generic 500 without leaking the message", () => {
-    const { host, status, json } = mockHost();
-    new WorkflowExceptionFilter().catch(new WorkflowError("internal detail: uuid xyz"), host);
+    const { host, status, send } = mockHost();
+    const errorSpy = vi.spyOn(Logger.prototype, "error").mockImplementation(() => {});
+    try {
+      new WorkflowExceptionFilter().catch(new WorkflowError("internal detail: uuid xyz"), host);
+    } finally {
+      errorSpy.mockRestore();
+    }
     expect(status).toHaveBeenCalledWith(500);
-    expect(json).toHaveBeenCalledWith({
+    expect(send).toHaveBeenCalledWith({
       statusCode: 500,
       error: "Internal Server Error",
       message: "Internal server error",
     });
+  });
+
+  it("logs the underlying error on the generic 500 path", () => {
+    const { host } = mockHost();
+    const errorSpy = vi.spyOn(Logger.prototype, "error").mockImplementation(() => {});
+    try {
+      new WorkflowExceptionFilter().catch(new WorkflowError("optimistic locking failure: xyz"), host);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toBe("optimistic locking failure: xyz");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("does not log on the mapped 404/409 paths", () => {
+    const errorSpy = vi.spyOn(Logger.prototype, "error").mockImplementation(() => {});
+    try {
+      const { host } = mockHost();
+      new WorkflowExceptionFilter().catch(new WorkflowInstanceNotFoundError("abc"), host);
+      new WorkflowExceptionFilter().catch(new InvalidEventError("abc", "draft", "approve"), host);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/packages/duraflows-nestjs/tests/unit/workflow-exception.filter.test.ts
+++ b/packages/duraflows-nestjs/tests/unit/workflow-exception.filter.test.ts
@@ -61,6 +61,22 @@ describe("WorkflowExceptionFilter", () => {
     }
   });
 
+  it("prefers the wrapped cause when logging the generic 500", () => {
+    const { host } = mockHost();
+    const errorSpy = vi.spyOn(Logger.prototype, "error").mockImplementation(() => {});
+    try {
+      const cause = new Error("ECONNREFUSED 127.0.0.1:5432");
+      new WorkflowExceptionFilter().catch(new WorkflowError("command resolution failed", cause), host);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      // The wrapper message stays for context, but the cause's message and
+      // stack are surfaced so the underlying failure is diagnosable.
+      expect(errorSpy.mock.calls[0][0]).toBe("command resolution failed (cause: ECONNREFUSED 127.0.0.1:5432)");
+      expect(errorSpy.mock.calls[0][1]).toBe(cause.stack);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("does not log on the mapped 404/409 paths", () => {
     const errorSpy = vi.spyOn(Logger.prototype, "error").mockImplementation(() => {});
     try {

--- a/packages/duraflows-nestjs/tests/unit/workflow-query.controller.test.ts
+++ b/packages/duraflows-nestjs/tests/unit/workflow-query.controller.test.ts
@@ -28,7 +28,7 @@ describe("WorkflowQueryController", () => {
   it("getHistory() delegates with parsed limit and offset", async () => {
     const { controller, workflowService } = createMocks();
 
-    await controller.getHistory({ workflowInstanceUuid: "uuid-1" } as any, { limit: "10", offset: "5" } as any);
+    await controller.getHistory({ workflowInstanceUuid: "uuid-1" } as any, { limit: 10, offset: 5 } as any);
 
     expect(workflowService.getHistory).toHaveBeenCalledWith("uuid-1", {
       limit: 10,

--- a/packages/duraflows-nestjs/tests/unit/workflow-timeout.controller.test.ts
+++ b/packages/duraflows-nestjs/tests/unit/workflow-timeout.controller.test.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import { describe, it, expect, vi } from "vitest";
 import { WorkflowTimeoutController } from "../../src/controllers/workflow-timeout.controller.js";
+import { TimeoutProcessQueryDto } from "../../src/controllers/dto/index.js";
 
 function createMocks() {
   const timeoutService = {
@@ -16,7 +17,7 @@ describe("WorkflowTimeoutController", () => {
   it("processExpired() delegates with parsed limit", async () => {
     const { controller, timeoutService } = createMocks();
 
-    const result = await controller.processExpired({ limit: "50" } as any);
+    const result = await controller.processExpired({ limit: 50 } as any);
 
     expect(timeoutService.processExpiredWorkflows).toHaveBeenCalledWith(50);
     expect(result.processed).toBe(3);
@@ -28,5 +29,24 @@ describe("WorkflowTimeoutController", () => {
     await controller.processExpired({} as any);
 
     expect(timeoutService.processExpiredWorkflows).toHaveBeenCalledWith(undefined);
+  });
+
+  it("rejects limit=0", async () => {
+    const { ValidationPipe } = await import("@nestjs/common");
+    const pipe = new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true });
+    await expect(pipe.transform({ limit: "0" }, { type: "query", metatype: TimeoutProcessQueryDto })).rejects.toThrow();
+  });
+
+  it("rejects unknown query fields", async () => {
+    const { ValidationPipe } = await import("@nestjs/common");
+    const pipe = new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true });
+    await expect(pipe.transform({ limt: "10" }, { type: "query", metatype: TimeoutProcessQueryDto })).rejects.toThrow();
+  });
+
+  it("transforms a valid string limit to a number", async () => {
+    const { ValidationPipe } = await import("@nestjs/common");
+    const pipe = new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true });
+    const result = await pipe.transform({ limit: "25" }, { type: "query", metatype: TimeoutProcessQueryDto });
+    expect(result.limit).toBe(25);
   });
 });

--- a/packages/duraflows-pg/README.md
+++ b/packages/duraflows-pg/README.md
@@ -19,6 +19,8 @@ Part of the [duraflows](https://github.com/camcima/duraflows) monorepo.
 pnpm add @duraflows/core @duraflows/pg pg
 ```
 
+> **Note:** `@duraflows/core` and `pg` are peer dependencies — you install them alongside this package so your app and the adapter share a single `Pool` driver and core instance.
+
 ## Quick Start
 
 ```ts

--- a/packages/duraflows-pg/README.md
+++ b/packages/duraflows-pg/README.md
@@ -60,15 +60,15 @@ export class AppModule {}
 
 ## Database Setup
 
-### Option 1: Copy the reference migration
+### Option 1: Copy the reference migrations
 
-A ready-made dbmate migration is shipped at:
+Ready-made dbmate migrations are shipped at:
 
 ```
-node_modules/@duraflows/pg/sql/dbmate/001_workflow_core.sql
+node_modules/@duraflows/pg/sql/dbmate/
 ```
 
-Copy it into your migration directory. It uses `gen_random_uuid()` (PostgreSQL 13+) for history record UUIDs.
+Copy **all** files in that directory (`001_workflow_core.sql`, `002_replace_trigger_with_metadata.sql`, `003_event_guards.sql`) into your migration directory and apply them in order. Applying only `001` produces a schema the current runtime cannot write to — `002`/`003` add the `metadata_json` handling and the `rejected_by` column / `guard-rejected` outcome that the history store requires. The migrations use `gen_random_uuid()` (PostgreSQL 13+) for history record UUIDs.
 
 ### Option 2: Generate with `generateMigrationSql()`
 

--- a/packages/duraflows-pg/package.json
+++ b/packages/duraflows-pg/package.json
@@ -41,7 +41,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "sql"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/duraflows-pg/package.json
+++ b/packages/duraflows-pg/package.json
@@ -40,9 +40,12 @@
       }
     }
   },
+  "sideEffects": false,
   "files": [
     "dist",
-    "sql"
+    "sql",
+    "!dist/**/*.tsbuildinfo",
+    "!dist/**/*.map"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/duraflows-pg/package.json
+++ b/packages/duraflows-pg/package.json
@@ -51,10 +51,13 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@duraflows/core": "^2.1.0",
     "pg": "^8.21.0"
   },
+  "peerDependencies": {
+    "@duraflows/core": "^2.1.0"
+  },
   "devDependencies": {
+    "@duraflows/core": "workspace:*",
     "@types/pg": "^8.11.0"
   }
 }

--- a/packages/duraflows-pg/package.json
+++ b/packages/duraflows-pg/package.json
@@ -53,14 +53,13 @@
   "scripts": {
     "build": "tsc --build"
   },
-  "dependencies": {
-    "pg": "^8.21.0"
-  },
   "peerDependencies": {
-    "@duraflows/core": "^2.1.0"
+    "@duraflows/core": "^2.1.0",
+    "pg": "^8.13.0"
   },
   "devDependencies": {
     "@duraflows/core": "workspace:*",
-    "@types/pg": "^8.11.0"
+    "@types/pg": "^8.11.0",
+    "pg": "^8.21.0"
   }
 }

--- a/packages/duraflows-pg/src/pg-history-store.ts
+++ b/packages/duraflows-pg/src/pg-history-store.ts
@@ -43,7 +43,7 @@ export class PgWorkflowHistoryStore implements WorkflowHistoryStore {
     const result = await client.query(
       `SELECT * FROM workflow_history
        WHERE workflow_instance_uuid = $1
-       ORDER BY created_at DESC
+       ORDER BY created_at DESC, uuid DESC
        LIMIT $2 OFFSET $3`,
       [workflowInstanceUuid, limit, offset],
     );

--- a/packages/duraflows-pg/tests/integration/pg-adapter.integration.test.ts
+++ b/packages/duraflows-pg/tests/integration/pg-adapter.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { randomUUID } from "node:crypto";
 import { Pool } from "pg";
 import { runInstanceStoreConformance } from "@duraflows/core/testing";
@@ -57,6 +57,12 @@ if (!databaseUrl) {
   });
 
   describe("pg adapter integration", () => {
+    // Cleanup runs in afterEach (not at the end of each test body) so a
+    // failing assertion cannot leak rows into the next test.
+    afterEach(async () => {
+      await pool.query("TRUNCATE workflow_history, workflow_instances CASCADE");
+    });
+
     it("findExpired executes against a real database and claims only expired rows", async () => {
       const expired = makeInstance({ expiresAt: new Date("2020-01-01T00:00:00Z") });
       const future = makeInstance({ expiresAt: new Date("2099-01-01T00:00:00Z") });
@@ -70,7 +76,6 @@ if (!databaseUrl) {
       const found = await transactionRunner.runInTransaction(() => instanceStore.findExpired(10, new Date()));
 
       expect(found.map((i) => i.uuid)).toEqual([expired.uuid]);
-      await pool.query("TRUNCATE workflow_history, workflow_instances CASCADE");
     });
 
     it("update with a stale version throws (optimistic locking against real WHERE clause)", async () => {
@@ -84,7 +89,6 @@ if (!databaseUrl) {
       await expect(transactionRunner.runInTransaction(() => instanceStore.update(instance))).rejects.toThrow(
         /Optimistic locking failure/,
       );
-      await pool.query("TRUNCATE workflow_history, workflow_instances CASCADE");
     });
 
     it("history round-trips guard-rejected outcome with rejected_by, and maps NULL to undefined", async () => {
@@ -120,7 +124,6 @@ if (!databaseUrl) {
       expect(guardRow.errorMessage).toBeUndefined(); // NULL must map to undefined, not null
       const successRow = records.find((r) => r.outcome === "success")!;
       expect(successRow.rejectedBy).toBeUndefined();
-      await pool.query("TRUNCATE workflow_history, workflow_instances CASCADE");
     });
   });
 }

--- a/packages/duraflows-pg/tests/integration/pg-adapter.integration.test.ts
+++ b/packages/duraflows-pg/tests/integration/pg-adapter.integration.test.ts
@@ -17,7 +17,14 @@ if (!databaseUrl) {
     it.skip("skipped", () => {});
   });
 } else {
-  const pool = new Pool({ connectionString: databaseUrl });
+  // `options` sets the backend `search_path` as a startup parameter, applied at
+  // connection establishment for EVERY pooled connection before any query runs.
+  // This isolates the suite's tables in a dedicated, throwaway schema so a
+  // DATABASE_URL accidentally pointed at a shared database can never DROP or
+  // TRUNCATE real tables in `public`. The path is duraflows_pg_it ONLY (no `public`) so
+  // the unqualified DDL/DML here stays inside the throwaway schema; built-ins
+  // like gen_random_uuid() resolve from pg_catalog regardless.
+  const pool = new Pool({ connectionString: databaseUrl, options: "-c search_path=duraflows_pg_it" });
   const transactionRunner = new PgTransactionRunner(pool);
   const instanceStore = new PgWorkflowInstanceStore(pool);
   const historyStore = new PgWorkflowHistoryStore(pool);
@@ -37,12 +44,28 @@ if (!databaseUrl) {
   });
 
   beforeAll(async () => {
-    await pool.query("DROP TABLE IF EXISTS workflow_history, workflow_instances CASCADE");
-    const { up } = generateMigrationSql();
-    await pool.query(up);
+    // Bootstrap the dedicated schema on a single client. CREATE SCHEMA is
+    // explicit (creates duraflows_pg_it regardless of search_path); every
+    // subsequent unqualified statement resolves into it via the pool's startup
+    // option. The name avoids the reserved pg_* prefix Postgres rejects.
+    const client = await pool.connect();
+    try {
+      await client.query("CREATE SCHEMA IF NOT EXISTS duraflows_pg_it");
+      await client.query("DROP TABLE IF EXISTS workflow_history, workflow_instances CASCADE");
+      const { up } = generateMigrationSql();
+      await client.query(up);
+    } finally {
+      client.release();
+    }
   });
 
   afterAll(async () => {
+    const client = await pool.connect();
+    try {
+      await client.query("DROP SCHEMA IF EXISTS duraflows_pg_it CASCADE");
+    } finally {
+      client.release();
+    }
     await pool.end();
   });
 

--- a/packages/duraflows-pg/tests/integration/pg-adapter.integration.test.ts
+++ b/packages/duraflows-pg/tests/integration/pg-adapter.integration.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+import { runInstanceStoreConformance } from "@duraflows/core/testing";
+import type { WorkflowInstance, WorkflowHistoryRecord } from "@duraflows/core";
+import {
+  PgWorkflowInstanceStore,
+  PgWorkflowHistoryStore,
+  PgTransactionRunner,
+  generateMigrationSql,
+} from "@duraflows/pg";
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  describe.skip("pg adapter integration (set DATABASE_URL to run)", () => {
+    it.skip("skipped", () => {});
+  });
+} else {
+  const pool = new Pool({ connectionString: databaseUrl });
+  const transactionRunner = new PgTransactionRunner(pool);
+  const instanceStore = new PgWorkflowInstanceStore(pool);
+  const historyStore = new PgWorkflowHistoryStore(pool);
+
+  const makeInstance = (overrides?: Partial<WorkflowInstance>): WorkflowInstance => ({
+    uuid: randomUUID(),
+    workflowName: "integration-test",
+    currentState: "initial",
+    version: 0,
+    expiresAt: null,
+    lastTransitionAt: new Date("2026-01-01T00:00:00Z"),
+    context: {},
+    metadata: {},
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  });
+
+  beforeAll(async () => {
+    await pool.query("DROP TABLE IF EXISTS workflow_history, workflow_instances CASCADE");
+    const { up } = generateMigrationSql();
+    await pool.query(up);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  runInstanceStoreConformance("pg (real PostgreSQL)", {
+    setup: async () => ({
+      store: instanceStore,
+      transactionRunner,
+      teardown: async () => {
+        await pool.query("TRUNCATE workflow_history, workflow_instances CASCADE");
+      },
+    }),
+  });
+
+  describe("pg adapter integration", () => {
+    it("findExpired executes against a real database and claims only expired rows", async () => {
+      const expired = makeInstance({ expiresAt: new Date("2020-01-01T00:00:00Z") });
+      const future = makeInstance({ expiresAt: new Date("2099-01-01T00:00:00Z") });
+      const noTimeout = makeInstance();
+      await transactionRunner.runInTransaction(async () => {
+        await instanceStore.create(expired);
+        await instanceStore.create(future);
+        await instanceStore.create(noTimeout);
+      });
+
+      const found = await transactionRunner.runInTransaction(() => instanceStore.findExpired(10, new Date()));
+
+      expect(found.map((i) => i.uuid)).toEqual([expired.uuid]);
+      await pool.query("TRUNCATE workflow_history, workflow_instances CASCADE");
+    });
+
+    it("update with a stale version throws (optimistic locking against real WHERE clause)", async () => {
+      const instance = makeInstance();
+      await transactionRunner.runInTransaction(() => instanceStore.create(instance));
+
+      instance.version = 1; // runtime convention: version is pre-incremented before update()
+      await transactionRunner.runInTransaction(() => instanceStore.update(instance));
+
+      // Re-issuing the same version (stale write) must not match any row.
+      await expect(transactionRunner.runInTransaction(() => instanceStore.update(instance))).rejects.toThrow(
+        /Optimistic locking failure/,
+      );
+      await pool.query("TRUNCATE workflow_history, workflow_instances CASCADE");
+    });
+
+    it("history round-trips guard-rejected outcome with rejected_by, and maps NULL to undefined", async () => {
+      const instance = makeInstance();
+      await transactionRunner.runInTransaction(() => instanceStore.create(instance));
+
+      const rejected: WorkflowHistoryRecord = {
+        workflowInstanceUuid: instance.uuid,
+        fromState: "initial",
+        eventName: "submit",
+        toState: "initial",
+        outcome: "guard-rejected",
+        rejectedBy: "can-submit",
+        commandResultsJson: [],
+      };
+      const success: WorkflowHistoryRecord = {
+        workflowInstanceUuid: instance.uuid,
+        fromState: "initial",
+        eventName: "submit",
+        toState: "submitted",
+        outcome: "success",
+        commandResultsJson: [{ ok: true, code: "DONE" }],
+      };
+      await transactionRunner.runInTransaction(async () => {
+        await historyStore.append(rejected);
+        await historyStore.append(success);
+      });
+
+      const records = await historyStore.findByInstanceUuid(instance.uuid);
+      expect(records).toHaveLength(2);
+      const guardRow = records.find((r) => r.outcome === "guard-rejected")!;
+      expect(guardRow.rejectedBy).toBe("can-submit");
+      expect(guardRow.errorMessage).toBeUndefined(); // NULL must map to undefined, not null
+      const successRow = records.find((r) => r.outcome === "success")!;
+      expect(successRow.rejectedBy).toBeUndefined();
+      await pool.query("TRUNCATE workflow_history, workflow_instances CASCADE");
+    });
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,9 +73,16 @@ importers:
       kysely:
         specifier: ^0.29.2
         version: 0.29.2
-      pg:
-        specifier: ^8.13.0
+    devDependencies:
+      '@duraflows/pg':
+        specifier: workspace:*
+        version: link:../duraflows-pg
+      '@types/pg':
+        specifier: ^8.11.0
         version: 8.20.0
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
 
   packages/duraflows-nestjs:
     dependencies:
@@ -700,9 +707,6 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/node@25.6.2':
-    resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
@@ -1760,14 +1764,8 @@ packages:
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
-  pg-cloudflare@1.3.0:
-    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
-
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
-
-  pg-connection-string@2.12.0:
-    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
 
   pg-connection-string@2.13.0:
     resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
@@ -1776,18 +1774,10 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
-  pg-pool@3.13.0:
-    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
-    peerDependencies:
-      pg: '>=8.0'
-
   pg-pool@3.14.0:
     resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
     peerDependencies:
       pg: '>=8.0'
-
-  pg-protocol@1.13.0:
-    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
 
   pg-protocol@1.14.0:
     resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
@@ -1795,15 +1785,6 @@ packages:
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
-
-  pg@8.20.0:
-    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
-    engines: {node: '>= 16.0.0'}
-    peerDependencies:
-      pg-native: '>=3.0.1'
-    peerDependenciesMeta:
-      pg-native:
-        optional: true
 
   pg@8.21.0:
     resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
@@ -2094,9 +2075,6 @@ packages:
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
-
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
@@ -2822,10 +2800,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@25.6.2':
-    dependencies:
-      undici-types: 7.19.2
-
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
@@ -2838,8 +2812,8 @@ snapshots:
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 25.6.2
-      pg-protocol: 1.13.0
+      '@types/node': 25.9.1
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/validator@13.15.10': {}
@@ -3874,27 +3848,16 @@ snapshots:
 
   perfect-debounce@2.1.0: {}
 
-  pg-cloudflare@1.3.0:
-    optional: true
-
   pg-cloudflare@1.4.0:
     optional: true
-
-  pg-connection-string@2.12.0: {}
 
   pg-connection-string@2.13.0: {}
 
   pg-int8@1.0.1: {}
 
-  pg-pool@3.13.0(pg@8.20.0):
-    dependencies:
-      pg: 8.20.0
-
   pg-pool@3.14.0(pg@8.21.0):
     dependencies:
       pg: 8.21.0
-
-  pg-protocol@1.13.0: {}
 
   pg-protocol@1.14.0: {}
 
@@ -3905,16 +3868,6 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
-
-  pg@8.20.0:
-    dependencies:
-      pg-connection-string: 2.12.0
-      pg-pool: 3.13.0(pg@8.20.0)
-      pg-protocol: 1.13.0
-      pg-types: 2.2.0
-      pgpass: 1.0.5
-    optionalDependencies:
-      pg-cloudflare: 1.3.0
 
   pg@8.21.0:
     dependencies:
@@ -4211,8 +4164,6 @@ snapshots:
       '@lukeed/csprng': 1.1.0
 
   uint8array-extras@1.5.0: {}
-
-  undici-types@7.19.2: {}
 
   undici-types@7.24.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,10 +69,6 @@ importers:
         version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.8(@types/node@25.9.1)(jiti@2.7.0))
 
   packages/duraflows-kysely:
-    dependencies:
-      kysely:
-        specifier: ^0.29.2
-        version: 0.29.2
     devDependencies:
       '@duraflows/core':
         specifier: workspace:*
@@ -83,6 +79,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
+      kysely:
+        specifier: ^0.29.2
+        version: 0.29.2
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -116,10 +115,6 @@ importers:
         version: 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
 
   packages/duraflows-pg:
-    dependencies:
-      pg:
-        specifier: ^8.21.0
-        version: 8.21.0
     devDependencies:
       '@duraflows/core':
         specifier: workspace:*
@@ -127,6 +122,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,16 +64,19 @@ importers:
       '@camcima/finita':
         specifier: ^3.0.0
         version: 3.0.0
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.8(@types/node@25.9.1)(jiti@2.7.0))
 
   packages/duraflows-kysely:
     dependencies:
-      '@duraflows/core':
-        specifier: ^2.1.0
-        version: link:../duraflows-core
       kysely:
         specifier: ^0.29.2
         version: 0.29.2
     devDependencies:
+      '@duraflows/core':
+        specifier: workspace:*
+        version: link:../duraflows-core
       '@duraflows/pg':
         specifier: workspace:*
         version: link:../duraflows-pg
@@ -86,15 +89,6 @@ importers:
 
   packages/duraflows-nestjs:
     dependencies:
-      '@duraflows/core':
-        specifier: ^2.1.0
-        version: link:../duraflows-core
-      '@nestjs/common':
-        specifier: ^11.1.24
-        version: 11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core':
-        specifier: ^11.1.24
-        version: 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -108,19 +102,28 @@ importers:
         specifier: ^7.0.0
         version: 7.8.2
     devDependencies:
+      '@duraflows/core':
+        specifier: workspace:*
+        version: link:../duraflows-core
+      '@nestjs/common':
+        specifier: ^11.1.24
+        version: 11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.1.24
+        version: 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/testing':
         specifier: ^11.1.24
         version: 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
 
   packages/duraflows-pg:
     dependencies:
-      '@duraflows/core':
-        specifier: ^2.1.0
-        version: link:../duraflows-core
       pg:
         specifier: ^8.21.0
         version: 8.21.0
     devDependencies:
+      '@duraflows/core':
+        specifier: workspace:*
+        version: link:../duraflows-core
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     // counted as 0% by v8 (because the file path coverage sees does not
     // match the package's compiled file path).
     alias: [
+      { find: /^@duraflows\/core\/testing$/, replacement: fromHere("./packages/duraflows-core/src/testing/index.ts") },
       { find: /^@duraflows\/core$/, replacement: fromHere("./packages/duraflows-core/src/index.ts") },
       { find: /^@duraflows\/nestjs$/, replacement: fromHere("./packages/duraflows-nestjs/src/index.ts") },
       { find: /^@duraflows\/pg$/, replacement: fromHere("./packages/duraflows-pg/src/index.ts") },


### PR DESCRIPTION
Implements fixes for every finding in `CODE_REVIEW.md` (2026-06-11). Each task was implemented, spec-reviewed, and verified; the full gate (build + lint + format + typecheck + 423 unit tests) is green, and the new real-PostgreSQL integration suite (19 tests) passes against postgres:16.

## Critical — broken consumer setup path
- **Ship `sql/` in the `@duraflows/pg` tarball** and rewrite the docs to reference the full migration set (`001`+`002`+`003`); `001` alone produces a schema the runtime can't write to.

## High
- **Reclassify framework/core packages as `peerDependencies`** (BREAKING → v3.0.0): `@nestjs/common`, `@nestjs/core`, and `@duraflows/core` are now peers of the adapters; `vitest` is an optional peer of `@duraflows/core` (for the `/testing` subpath); the unused `pg` peer of `@duraflows/kysely` was dropped. Release hook + `RELEASING.md` updated to re-pin `peerDependencies.@duraflows/core`.
- **Map domain errors to HTTP statuses** via a new `WorkflowExceptionFilter` (`WorkflowInstanceNotFoundError` → 404, `InvalidEventError` → 409, others → generic 500 without leaking internals). Adds `WorkflowInstanceNotFoundError` to core.
- **Real-PostgreSQL integration tests** for both adapters (conformance suite + regressions for `findExpired`, optimistic locking, NULL→undefined mapping), gated on `DATABASE_URL`, plus a CI job with a `postgres:16` service container.

## Medium
- `deepFreeze` now neutralizes `Map`/`Set` mutators and freezes their entries.
- Documented the version-increment / `SKIP LOCKED` persistence contracts; added a stale-version conformance test (in-memory store now enforces optimistic locking too).
- `forRootAsync` `inject` is type-correlated with the factory params via a mapped tuple.
- Clear error when a command provider isn't singleton-scoped.
- Excluded `*.map`/`*.tsbuildinfo` from tarballs; added `sideEffects: false`.
- Controller query params are typed, bounded (`@Min`/`@Max`), and `forbidNonWhitelisted` rejects unknown fields.

## Low
- Stable history ordering (`created_at DESC, uuid DESC`); mermaid node-id sanitization + label escaping; unreachable-state validator warnings; `triggerMetadata` cloned into history + no-onEnter `create` wrapped in a transaction; `WorkflowExecutionContext.now` marked `readonly`; docs for REST auth caveat and JSON context fidelity.

## Intentionally not changed
- The reviewer-flagged "`findExpired` SQL clause order" was a **false positive** — verified valid against PostgreSQL 16; left as-is.
- Configurable schema/table prefixes (not a defect) and the observer/`onObserverError` items (already correct) were deferred.

> **Note:** the peerDependency change is breaking — release as **v3.0.0** via the normal release-it flow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)