### PR TITLE
ci(osv-scanner): reliably ignore npm dev-tooling vulns

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,6 +1,23 @@
-# Ignore dev dependency vulnerabilities — this library ships zero runtime deps
-# in the core package. Dev deps only affect the local development workflow,
-# not consumers.
+# osv-scanner runs against pnpm-lock.yaml, which is almost entirely development
+# tooling. The published packages share exactly ONE runtime dependency:
+# @camcima/finita (a first-party, zero-dependency leaf) via @duraflows/core. The
+# adapters take their runtime deps (pg, kysely, @nestjs/*) as peerDependencies,
+# so those belong to the consumer's tree, not ours.
+#
+# Dev-tooling vulnerabilities affect only the local dev/test workflow, never
+# consumers, so they must not fail CI. `group = "dev"` is the intuitive filter,
+# but osv-scanner cannot classify pnpm (lockfileVersion 9) TRANSITIVE dev deps
+# as "dev", so transitive dev tooling (vite, undici, js-yaml, ...) failed CI
+# regardless. Ignoring the npm ecosystem is the reliable, low-maintenance way to
+# drop that noise.
+#
+# TRADE-OFF: this also suppresses advisories for @camcima/finita. That is
+# tolerable here (first-party, zero transitive deps), but it is the one
+# consumer-facing package this scan would otherwise cover. If finita gains
+# advisories or a real third-party runtime dependency is ever added, narrow this
+# rule (e.g. ignore by explicit package name) and/or enable Dependabot security
+# alerts so that dependency stays under watch.
 [[PackageOverrides]]
-group = "dev"
+ecosystem = "npm"
 ignore = true
+reason = "npm tree is dev tooling plus first-party @camcima/finita; consumer-facing deps are peers"


### PR DESCRIPTION
Makes the dev-dependency ignore in `osv-scanner.toml` **actually work**, so osv-scanner stops failing CI on dev-tooling CVEs going forward (not just for today's vite/undici/js-yaml).

## Root cause
The existing `[[PackageOverrides]] group = "dev"` filter is a no-op for this repo: osv-scanner **cannot classify pnpm v9 _transitive_ dev dependencies as "dev"**, so transitive dev tooling (vite via vitest, undici, js-yaml, …) slipped through and failed CI on every run — even though the intent was to ignore exactly those.

## Fix
Ignore the **npm ecosystem** instead. Here that's the reliable expression of the same intent: the npm tree is dev tooling plus one first-party runtime dep, `@camcima/finita` (a zero-dependency leaf via `@duraflows/core`). The adapters' runtime deps (`pg`, `kysely`, `@nestjs/*`) are `peerDependencies` — the consumer's tree, not ours.

## Verification
Tested the mechanism in isolation with osv-scanner v2.3.8 (CI's image):
- A lockfile pinning **lodash 4.17.15** (6 known CVEs) → **fails** (exit 1) without the rule.
- Same lockfile **with** `ecosystem = "npm" ignore = true` → *"Package npm/lodash/… filtered out … No issues found"* (exit 0).

osv-scanner now passes on this repo's tree, and `format:check` is unaffected.

## ⚠️ Trade-off you should weigh before merging
This also suppresses advisories for **`@camcima/finita`** — the one consumer-facing runtime dependency. I'm flagging it because:
- The prior config comment claimed "zero runtime deps," which is **inaccurate** — finita *is* a runtime dep of `@duraflows/core`. (Corrected in this PR.)
- `@camcima/finita` is first-party (your package) with zero transitive deps, so the practical risk is low — but with this rule, osv-scanner won't catch a finita advisory.
- **Dependabot security alerts appear to be disabled** on this repo (`GET /vulnerability-alerts` → 404), so there's currently no other automated backstop for it.

**Options if you'd rather keep finita covered:** enable Dependabot security alerts (covers the real dep graph, including finita), and/or I can narrow this rule to ignore dev tooling by name and leave finita enforced. Happy to do either.

osv-scanner is a non-required check, so this is purely about keeping CI green/clean.
