### PR TITLE
fix(deps): upgrade @camcima/finita to v4

### DIFF
--- a/packages/duraflows-core/package.json
+++ b/packages/duraflows-core/package.json
@@ -63,7 +63,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@camcima/finita": "^3.0.0"
+    "@camcima/finita": "^4.0.0"
   },
   "peerDependencies": {
     "vitest": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
   packages/duraflows-core:
     dependencies:
       '@camcima/finita':
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^4.0.0
+        version: 4.0.0
       vitest:
         specifier: ^4.0.0
         version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
@@ -160,8 +160,8 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
-  '@camcima/finita@3.0.0':
-    resolution: {integrity: sha512-QdCC9zmvUg7e5iMFFvb5UeD0hyNicUEMhi21MmHZwS6Eqtv0TV8mWKaNxaQgtZvjOLsLHGbxM85fR3OQjvZOrg==}
+  '@camcima/finita@4.0.0':
+    resolution: {integrity: sha512-1Fq9k4gKw9pIeTFLnVWhHQcLsKpk9lJqDSgUC4ZL4cVvgSt/9FTAnQDY2nvemUpfli+iOB8YM/Pwn9NPqsTxrg==}
     engines: {node: '>=20.0.0'}
 
   '@commitlint/cli@21.0.2':
@@ -2281,7 +2281,7 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
-  '@camcima/finita@3.0.0': {}
+  '@camcima/finita@4.0.0': {}
 
   '@commitlint/cli@21.0.2(@types/node@25.9.1)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
Upgrades `@duraflows/core`'s runtime dependency `@camcima/finita` from `^3.0.0` to `^4.0.0` (resolves 4.0.0).

## Impact: none on duraflows behavior
Build is clean and **all 455 tests pass with no source changes**. duraflows uses finita only through `ProcessBuilder`, `CallbackCondition`, and `Statemachine.triggerEvent` — and I checked every v4 breaking change against that surface:

| v4 breaking change | Used by duraflows? |
|---|---|
| `Observer.update(args)` / `getInvokeArgs()` | No — duraflows has its own observer system |
| `TransitionFrame.subject` added | No — never constructs frames |
| `AutomaticTransitionCycleError` field rename | No — no automatic transitions |
| Stricter state/condition **name validation** | Safe — internal condition names are clean; surfaces malformed *consumer* state names (improvement) |
| Duplicate-transition weight conflict throws | No — never sets weights or duplicate `(from,event,to)` |
| Empty `initialStateName` throws | Safe — surfaces corrupted persisted state (improvement) |
| Re-entrant `triggerEvent` → `ReentrancyError` | No — conditions only read context; no re-entrant triggers |
| Failed lock-release rejects | No — no finita mutex configured |

## Not a breaking change for duraflows
- finita v4 keeps **`engines.node >= 20`** — no engine bump (the v2→v3 upgrade was a duraflows major *because* it raised Node to 20; this one doesn't).
- finita is a regular `dependency` of `@duraflows/core`, fully wrapped — consumers don't import it directly.
- The only behavioral differences are stricter validation that turns previously-silent corruption (empty/whitespace state names, empty persisted state) into clear errors.

So this is a non-breaking dependency update — suitable for a `fix(deps)` minor/patch duraflows release, not a major. (Final version call is yours at release time.)
