### PR TITLE
chore: release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.1.0](https://github.com/camcima/duraflows/compare/v3.0.0...v3.1.0) (2026-06-23)
+
+### Bug Fixes
+
+* **deps:** upgrade @camcima/finita to v4 ([99c0464](https://github.com/camcima/duraflows/commit/99c04645c0a19a506dedbfb5c1dd00ca98823896))
+
 ## [3.0.0](https://github.com/camcima/duraflows/compare/v2.1.0...v3.0.0) (2026-06-23)
 
 ### ⚠ BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "duraflows-persistence-adapter": "skills/duraflows-persistence-adapter/SKILL.md",
     "duraflows-reviewer": "skills/duraflows-reviewer/SKILL.md"
   },
-  "version": "3.0.0",
+  "version": "3.1.0",
   "license": "MIT"
 }

--- a/packages/duraflows-core/package.json
+++ b/packages/duraflows-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duraflows/core",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Framework-agnostic durable workflow runtime for TypeScript, built on @camcima/finita. Ships the runtime, types, persistence interfaces, and observer hooks.",
   "keywords": [
     "workflow",

--- a/packages/duraflows-kysely/package.json
+++ b/packages/duraflows-kysely/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duraflows/kysely",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "PostgreSQL persistence adapter for duraflows using `kysely`. Integrates with kysely's type-safe query builder and AsyncLocalStorage-based transaction context.",
   "keywords": [
     "duraflows",
@@ -54,7 +54,7 @@
     "build": "tsc --build"
   },
   "peerDependencies": {
-    "@duraflows/core": "^3.0.0",
+    "@duraflows/core": "^3.1.0",
     "kysely": "^0.29.2"
   },
   "devDependencies": {

--- a/packages/duraflows-nestjs/package.json
+++ b/packages/duraflows-nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duraflows/nestjs",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "NestJS integration for duraflows: dependency injection, services, optional REST controllers, and @WorkflowCommand decorator for DI-backed command handlers.",
   "keywords": [
     "duraflows",
@@ -57,7 +57,7 @@
     "class-validator": "^0.15.1"
   },
   "peerDependencies": {
-    "@duraflows/core": "^3.0.0",
+    "@duraflows/core": "^3.1.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "reflect-metadata": "^0.2.0",

--- a/packages/duraflows-pg/package.json
+++ b/packages/duraflows-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duraflows/pg",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "PostgreSQL persistence adapter for duraflows using `pg`. Provides transaction runner, workflow instance store, and history store with row-level locking for safe concurrent access.",
   "keywords": [
     "duraflows",
@@ -54,7 +54,7 @@
     "build": "tsc --build"
   },
   "peerDependencies": {
-    "@duraflows/core": "^3.0.0",
+    "@duraflows/core": "^3.1.0",
     "pg": "^8.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Release **v3.1.0** — minor bump for the finita v4 upgrade.

Version bump + CHANGELOG only (prepared with the prepare-only `release-it`; nothing tagged or published yet — Phase 2 happens after merge).

### Contents
- All four packages + root bumped to `3.1.0`; internal `@duraflows/core` peer re-pinned to `^3.1.0`.
- CHANGELOG `3.1.0` section: **fix(deps): upgrade @camcima/finita to v4** (the other commits since v3.0.0 are ci/chore, hidden by the changelog preset).

Verified locally: `pnpm run build` + `pnpm test` green (455 passed).